### PR TITLE
v8.0.4 - Clearing info leaving a battleground

### DIFF
--- a/BattlegroundWinConditions.lua
+++ b/BattlegroundWinConditions.lua
@@ -58,6 +58,8 @@ do
 
   function BGWC:PLAYER_LEAVING_WORLD()
     self:UnregisterEvent("PLAYER_LEAVING_WORLD")
+
+    Interface:ClearInterface()
     zoneIds[prevZone]:ExitZone()
   end
 

--- a/BattlegroundWinConditions.toc
+++ b/BattlegroundWinConditions.toc
@@ -1,15 +1,17 @@
 ## Interface: 100200
 ## Title: BattlegroundWinConditions
 ## Version: 8.0.3
-## Author: RBGDEV
+## Author: Ajax
 ## Notes: Battleground Win Conditions
+## X-Flavor: Mainline
+## X-Category: Battlegrounds/PvP
 ## X-Credits: Ajax
 ## X-License: All Rights Reserved
 ## X-Website: https://www.curseforge.com/wow/addons/battleground-win-conditions
-## DefaultState: Enabled
-## SavedVariables: BGWCDB
 ## X-Curse-Project-ID: 932307
 ## X-Wago-ID: 96E7paGg
+## DefaultState: Enabled
+## SavedVariables: BGWCDB
 
 core/config.lua
 core/helpers.lua

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # battleground-win-conditions
+
+Credits:
+
+- AB Win Conditions for WoTLK which was the original (now outdated for this code) base logic for reference: https://wago.io/lXPWRRs8A
+- Capping addon for code reference to timers and performant base + score updates: https://www.curseforge.com/wow/addons/capping-bg-timers
+- Hazal and the OG Custom Capping addon that had future win info in it to use for reference, along with his direct help in this new work
+- Diminish for code reference on addon structure and best practices: https://www.curseforge.com/wow/addons/diminish
+- ALL of the people who directly helped me test this over the past few months and sent vods and screenshots for bugs and feature ideas


### PR DESCRIPTION
Runs the ClearInterface command when "leaving world", which for this case is leaving the bg.

This code runs before loading screen disabled which if you have placeholder info turned on will show the placeholder info after as intended.

- resetting game info when leaving battleground
- update the user experience for the anchor