### PR TITLE
v8.0.5 - Fixing EOTS

### DIFF
--- a/BattlegroundWinConditions.toc
+++ b/BattlegroundWinConditions.toc
@@ -1,8 +1,8 @@
 ## Interface: 100200
 ## Title: BattlegroundWinConditions
-## Version: 8.0.4
+## Version: 8.0.5
 ## Author: Ajax
-## Notes: Battleground Win Conditions
+## Notes: Provides real time win conditions for battlegrounds
 ## X-Flavor: Mainline
 ## X-Category: Battlegrounds/PvP
 ## X-Credits: Ajax

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Battleground Win Conditions
 
+## [v8.0.5](https://github.com/rbgdevx/battleground-win-conditions/releases/tag/v8.0.5) (2023-12-16)
+
+- removing the check for if you're in a random eots game as it produced incorrect results, and realistically we dont need to exclude eots from incoming base code because there will never trigger an incoming base on eots as that mechanism doesn't exist there, and on rated eots we always want the normal code anyways so its a win win to just remove the extra logic
+
 ## [v8.0.4](https://github.com/rbgdevx/battleground-win-conditions/releases/tag/v8.0.4) (2023-12-15)
+
+- resetting game info when leaving battleground
+- update the user experience for the anchor
 
 ## [v8.0.3](https://github.com/rbgdevx/battleground-win-conditions/releases/tag/v8.0.3) (2023-12-12)
 

--- a/core/config.lua
+++ b/core/config.lua
@@ -40,6 +40,6 @@ NS.DEFAULT_SETTINGS = {
   },
 }
 
-NS.Static_Version = 804
+NS.Static_Version = 805
 NS.Version = GetAddOnMetadata(AddonName, "Version")
 NS.FoundNewVersion = false


### PR DESCRIPTION
Removes the logic that checked if you were in a random EOTS map or not since in random eots you dont cap bases like normal however this had bugs in the code and after evaluating the solutions i realized that there is no incoming base mechanism in random eots since when a base isn't controlled it isn't contested by anyone, it's neutral/un-controlled so the incoming base logic never gets triggered anyways. So we could just safely remove all the business logic to check for random eots and run the normal code and it wouldn't have any effect and this would fix EOTS rated as well (which ironically the bug was firing on eots even though i was checking for random eots zone id so they might have been the same id or the wrong id passed to the function), regardless was just easier to remove the logic completely.

- removing the check for if you're in a random eots game as it produced incorrect results, and realistically we dont need to exclude eots from incoming base code because there will never trigger an incoming base on eots as that mechanism doesn't exist there, and on rated eots we always want the normal code anyways so its a win win to just remove the extra logic