### PR TITLE
v8.0.6 - Matching cap needs to owned needs

### DIFF
--- a/BattlegroundWinConditions.toc
+++ b/BattlegroundWinConditions.toc
@@ -1,6 +1,6 @@
 ## Interface: 100200
 ## Title: BattlegroundWinConditions
-## Version: 8.0.5
+## Version: 8.0.6
 ## Author: Ajax
 ## Notes: Provides real time win conditions for battlegrounds
 ## X-Flavor: Mainline

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Battleground Win Conditions
 
+## [v8.0.6](https://github.com/rbgdevx/battleground-win-conditions/releases/tag/v8.0.6) (2023-12-16)
+
+- making sure future need info during an assault matches what you need after the bases cap over and become owned
+
 ## [v8.0.5](https://github.com/rbgdevx/battleground-win-conditions/releases/tag/v8.0.5) (2023-12-16)
 
 - removing the check for if you're in a random eots game as it produced incorrect results, and realistically we dont need to exclude eots from incoming base code because there will never trigger an incoming base on eots as that mechanism doesn't exist there, and on rated eots we always want the normal code anyways so its a win win to just remove the extra logic

--- a/core/config.lua
+++ b/core/config.lua
@@ -40,6 +40,6 @@ NS.DEFAULT_SETTINGS = {
   },
 }
 
-NS.Static_Version = 805
+NS.Static_Version = 806
 NS.Version = GetAddOnMetadata(AddonName, "Version")
 NS.FoundNewVersion = false

--- a/core/helpers.lua
+++ b/core/helpers.lua
@@ -131,10 +131,10 @@ NS.checkWinCondition = function(
     local l = NS.getWinTime(maxScore, loseGapScore, resources[potentialLoseTeamBaseCount])
     local w = NS.getWinTime(maxScore, winGapScore, resources[potentialWinTeamBaseCount])
 
-    local scoreCheck = (currentWinTime < (NS.ASSAULT_TIME + NS.CONTESTED_TIME)) and winTeamScoreNow or winGapScore
+    local scoreCheck = winTeamScoreNow
 
     if l < w and scoreCheck < maxScore then
-      local ownTime = time
+      local ownTime = (currentWinTime < (NS.ASSAULT_TIME + NS.CONTESTED_TIME)) and time or time + winTimeIncrease
       local capTime = ownTime - NS.ASSAULT_TIME
       local ownScore = scoreCheck
       local capScore = ownScore - assaultScore


### PR DESCRIPTION
When you're the losing team the code tells you what you need to win with, and that info wasn't matching always what you needed after the enemy bases capped over.

This addresses that and ensures during an assault by the enemy where you're losing that what you need matches what you'll still need when the bases cap over.

- making sure future need info during an assault matches what you need after the bases cap over and become owned