### PR TITLE
v8.0.7 - Creating new banner only option

### DIFF
--- a/BattlegroundWinConditions.lua
+++ b/BattlegroundWinConditions.lua
@@ -14,6 +14,7 @@ local UnitName = UnitName
 local GetRealmName = GetRealmName
 local strsplit = strsplit
 local tonumber = tonumber
+local print = print
 
 local sformat = string.format
 
@@ -50,9 +51,12 @@ do
 
   function BGWC:Enable(instanceID)
     self:RegisterEvent("PLAYER_LEAVING_WORLD")
+
     prevZone = instanceID
     Interface:ClearInterface()
     NS.PLAYER_FACTION = GetPlayerFactionGroup()
+    NS.IN_GAME = true
+
     zoneIds[instanceID]:EnterZone(instanceID)
   end
 
@@ -60,6 +64,8 @@ do
     self:UnregisterEvent("PLAYER_LEAVING_WORLD")
 
     Interface:ClearInterface()
+    NS.IN_GAME = false
+
     zoneIds[prevZone]:ExitZone()
   end
 
@@ -104,6 +110,7 @@ function BGWC:CHAT_MSG_ADDON(prefix, version, _, sender, ...)
     local messageEx = { strsplit(";", version) }
     if messageEx[1] == "Version" then
       print("NS.FoundNewVersion", NS.FoundNewVersion, tonumber(messageEx[2]), NS.Static_Version)
+
       if not NS.FoundNewVersion and tonumber(messageEx[2]) > NS.Static_Version then
         local text = sformat("New version released!")
         NS.write(text)
@@ -123,7 +130,11 @@ function BGWC:LOADING_SCREEN_DISABLED()
 
   NS.Timer(0, function() -- Timers aren't fully functional until 1 frame after loading is done
     if NS.db.test then
-      Interface:CreateTestInfo()
+      if NS.db.banner then
+        Interface:CreateTestBannerInfo()
+      else
+        Interface:CreateTestInfo()
+      end
     end
   end)
 end

--- a/BattlegroundWinConditions.toc
+++ b/BattlegroundWinConditions.toc
@@ -1,6 +1,6 @@
 ## Interface: 100200
 ## Title: BattlegroundWinConditions
-## Version: 8.0.6
+## Version: 8.0.7
 ## Author: Ajax
 ## Notes: Provides real time win conditions for battlegrounds
 ## X-Flavor: Mainline

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Battleground Win Conditions
 
+## [v8.0.7](https://github.com/rbgdevx/battleground-win-conditions/releases/tag/v8.0.7) (2023-12-17)
+
+- providing an option to be able to only show the win banner if desired
+- abstracting out all global functions and utils possible to local vars for performance
+
 ## [v8.0.6](https://github.com/rbgdevx/battleground-win-conditions/releases/tag/v8.0.6) (2023-12-16)
 
 - making sure future need info during an assault matches what you need after the bases cap over and become owned

--- a/core/api.lua
+++ b/core/api.lua
@@ -3,6 +3,7 @@ local _, NS = ...
 local API = {}
 NS.API = API
 
+local next = next
 local IsInRaid = IsInRaid
 local IsInGroup = IsInGroup
 local IsInGuild = IsInGuild

--- a/core/config.lua
+++ b/core/config.lua
@@ -15,6 +15,7 @@ NS.LOSE_NOUN = "They"
 NS.ASSAULT_TIME = 5
 NS.CONTESTED_TIME = 60
 NS.ORB_BUFF_TIME = 45
+NS.IN_GAME = false
 
 NS.dummyFrame = NS.dummyFrame or CreateFrame("Frame")
 NS.barFrameMT = NS.barFrameMT or { __index = NS.dummyFrame }
@@ -32,6 +33,7 @@ NS.DEFAULT_SETTINGS = {
   version = 8,
   lock = false,
   test = true,
+  banner = false,
   position = {
     "CENTER",
     "CENTER",

--- a/core/config.lua
+++ b/core/config.lua
@@ -44,6 +44,6 @@ NS.DEFAULT_SETTINGS = {
   },
 }
 
-NS.Static_Version = 806
+NS.Static_Version = 807
 NS.Version = GetAddOnMetadata(AddonName, "Version")
 NS.FoundNewVersion = false

--- a/core/config.lua
+++ b/core/config.lua
@@ -16,6 +16,8 @@ NS.ASSAULT_TIME = 5
 NS.CONTESTED_TIME = 60
 NS.ORB_BUFF_TIME = 45
 NS.IN_GAME = false
+NS.IS_TEMPLE = false
+NS.IS_EOTS = false
 
 NS.dummyFrame = NS.dummyFrame or CreateFrame("Frame")
 NS.barFrameMT = NS.barFrameMT or { __index = NS.dummyFrame }

--- a/core/helpers.lua
+++ b/core/helpers.lua
@@ -2,8 +2,11 @@ local _, NS = ...
 
 local tostring = tostring
 local pairs = pairs
+local ipairs = ipairs
 local type = type
 local next = next
+local GetTime = GetTime
+local print = print
 
 local sformat = string.format
 local mfloor = math.floor

--- a/interface/banner.lua
+++ b/interface/banner.lua
@@ -7,6 +7,11 @@ NS.barCache = NS.barCache or {}
 local barPrototype_meta = NS.barPrototype_mt
 local barCache = NS.barCache
 
+local next = next
+local GetTime = GetTime
+local CreateFrame = CreateFrame
+local setmetatable = setmetatable
+
 local mmin = math.min
 local mmax = math.max
 

--- a/interface/orbbufftimer.lua
+++ b/interface/orbbufftimer.lua
@@ -7,6 +7,11 @@ NS.buffCache = NS.buffCache or {}
 local barPrototype_meta = NS.barPrototype_mt
 local buffCache = NS.buffCache
 
+local next = next
+local GetTime = GetTime
+local CreateFrame = CreateFrame
+local setmetatable = setmetatable
+
 local mmin = math.min
 local mmax = math.max
 
@@ -99,6 +104,17 @@ function OrbBuffTimer:Start(bar, winTeam)
 
   bar.updater:SetScript("OnLoop", buffUpdate)
   bar.updater:Play()
+
+  if NS.db.banner == false then
+    bar:Show()
+  end
+end
+
+function OrbBuffTimer:HideBuff(bar)
+  bar:Hide()
+end
+
+function OrbBuffTimer:ShowBuff(bar)
   bar:Show()
 end
 

--- a/interface/orbbufftimer.lua
+++ b/interface/orbbufftimer.lua
@@ -105,17 +105,15 @@ function OrbBuffTimer:Start(bar, winTeam)
   bar.updater:SetScript("OnLoop", buffUpdate)
   bar.updater:Play()
 
-  if NS.db.banner == false then
-    bar:Show()
-  end
+  bar:Show()
 end
 
 function OrbBuffTimer:HideBuff(bar)
-  bar:Hide()
+  bar:SetAlpha(0)
 end
 
 function OrbBuffTimer:ShowBuff(bar)
-  bar:Show()
+  bar:SetAlpha(1)
 end
 
 function OrbBuffTimer:UpdateBuff(bar, remaining, winTeam)

--- a/interface/wininfo.lua
+++ b/interface/wininfo.lua
@@ -7,6 +7,11 @@ NS.infoCache = NS.infoCache or {}
 local barPrototype_meta = NS.barPrototype_mt
 local infoCache = NS.infoCache
 
+local next = next
+local GetTime = GetTime
+local CreateFrame = CreateFrame
+local setmetatable = setmetatable
+
 local mmin = math.min
 local mmax = math.max
 local sformat = string.format
@@ -263,8 +268,19 @@ function WinInfo:Start(bar, winTable)
 
     bar.updater:SetScript("OnLoop", infoUpdate)
     bar.updater:Play()
-    bar:Show()
+
+    if NS.db.banner == false then
+      bar:Show()
+    end
   end
+end
+
+function WinInfo:HideInfo(bar)
+  bar:Hide()
+end
+
+function WinInfo:ShowInfo(bar)
+  bar:Show()
 end
 
 function WinInfo:UpdateInfo(bar, remaining, winTable)

--- a/interface/wininfo.lua
+++ b/interface/wininfo.lua
@@ -269,18 +269,16 @@ function WinInfo:Start(bar, winTable)
     bar.updater:SetScript("OnLoop", infoUpdate)
     bar.updater:Play()
 
-    if NS.db.banner == false then
-      bar:Show()
-    end
+    bar:Show()
   end
 end
 
 function WinInfo:HideInfo(bar)
-  bar:Hide()
+  bar:SetAlpha(0)
 end
 
 function WinInfo:ShowInfo(bar)
-  bar:Show()
+  bar:SetAlpha(1)
 end
 
 function WinInfo:UpdateInfo(bar, remaining, winTable)

--- a/maps/ArathiBasin.lua
+++ b/maps/ArathiBasin.lua
@@ -2,6 +2,8 @@ local _, NS = ...
 
 local mod = NS.API:NewMod()
 
+local next = next
+
 local instanceIdToMapId = {
   -- ArathiBasin
   [2107] = {

--- a/maps/DeepwindGorge.lua
+++ b/maps/DeepwindGorge.lua
@@ -2,6 +2,8 @@ local _, NS = ...
 
 local mod = NS.API:NewMod()
 
+local next = next
+
 local instanceIdToMapId = {
   -- DeepwindGorge
   [2245] = {

--- a/maps/EyeoftheStorm.lua
+++ b/maps/EyeoftheStorm.lua
@@ -2,6 +2,8 @@ local _, NS = ...
 
 local mod = NS.API:NewMod()
 
+local next = next
+
 local instanceIdToMapId = {
   -- EyeoftheStorm
   -- only iconState 1 has flag info
@@ -48,6 +50,7 @@ local instanceIdToMapId = {
 }
 
 function mod:EnterZone(id)
+  NS.IS_EOTS = true
   NS.Info:StartBaseTracker(instanceIdToMapId[id].id, instanceIdToMapId[id].maxBases, 60)
   NS.Info:StartScoreTracker(
     instanceIdToMapId[id].id,
@@ -58,6 +61,7 @@ function mod:EnterZone(id)
 end
 
 function mod:ExitZone()
+  NS.IS_EOTS = false
   NS.Info:StopScoreTracker()
   NS.Info:StopBaseTracker()
 end

--- a/maps/TempleofKotmogu.lua
+++ b/maps/TempleofKotmogu.lua
@@ -2,6 +2,8 @@ local _, NS = ...
 
 local mod = NS.API:NewMod()
 
+local next = next
+
 local instanceIdToMapId = {
   -- TempleofKotmogu
   -- Points for the positions:
@@ -23,10 +25,12 @@ local instanceIdToMapId = {
 }
 
 function mod:EnterZone(id)
+  NS.IS_TEMPLE = true
   NS.Info:StartBaseTracker(instanceIdToMapId[id].id, instanceIdToMapId[id].maxBases)
 end
 
 function mod:ExitZone()
+  NS.IS_TEMPLE = false
   NS.Info:StopBaseTracker()
 end
 

--- a/maps/TheBattleforGilneas.lua
+++ b/maps/TheBattleforGilneas.lua
@@ -2,6 +2,8 @@ local _, NS = ...
 
 local mod = NS.API:NewMod()
 
+local next = next
+
 local instanceIdToMapId = {
   -- Gilneas
   [761] = {

--- a/modules/Interface.lua
+++ b/modules/Interface.lua
@@ -3,9 +3,12 @@ local _, NS = ...
 local Interface = {}
 NS.Interface = Interface
 
-local InterfaceFrame = CreateFrame("Frame", "BGWCInterfaceFrame", UIParent)
+local CreateFrame = CreateFrame
+local GetTime = GetTime
 
 local sformat = string.format
+
+local InterfaceFrame = CreateFrame("Frame", "BGWCInterfaceFrame", UIParent)
 
 -- IMPORTANT: don't use this more than once
 -- I removed support for creating multiple
@@ -81,32 +84,70 @@ function Interface:StopBuff(bar)
   NS.OrbBuffTimer:StopBuff(bar)
 end
 
+function Interface:HideInfo(bar)
+  NS.WinInfo:HideInfo(bar)
+end
+
+function Interface:HideBuff(bar)
+  NS.OrbBuffTimer:HideBuff(bar)
+end
+
+function Interface:ShowInfo(bar)
+  NS.WinInfo:ShowInfo(bar)
+end
+
+function Interface:ShowBuff(bar)
+  NS.OrbBuffTimer:ShowBuff(bar)
+end
+
 function Interface:UpdateText(bar, txt)
   bar:SetText(txt)
 end
 
-function Interface:ClearText(bar)
-  bar:SetText("")
+function Interface:Hide(bar)
+  bar:Hide()
+end
+
+function Interface:Show(bar)
+  bar:Show()
 end
 
 function Interface:ClearAllText()
-  self:ClearText(InterfaceFrame.score)
-  self:ClearText(InterfaceFrame.flag)
+  self:UpdateText(InterfaceFrame.score, "")
+  self:UpdateText(InterfaceFrame.flag, "")
 end
 
-function Interface:ClearInterface()
-  self:StopBanner(InterfaceFrame.banner)
+function Interface:HideAllText()
+  self:Hide(InterfaceFrame.score)
+  self:Hide(InterfaceFrame.flag)
+end
+
+function Interface:ShowAllText()
+  self:Show(InterfaceFrame.score)
+  self:Show(InterfaceFrame.flag)
+end
+
+function Interface:ClearWinInfo()
   self:StopInfo(InterfaceFrame.info)
   self:StopBuff(InterfaceFrame.buff)
   self:ClearAllText()
 end
 
-function Interface:ToggleInterface(value)
-  InterfaceFrame.banner:SetShown(value)
-  InterfaceFrame.info:SetShown(value)
-  InterfaceFrame.buff:SetShown(value)
-  InterfaceFrame.score:SetShown(value)
-  InterfaceFrame.flag:SetShown(value)
+function Interface:HideWinInfo()
+  self:HideInfo(InterfaceFrame.info)
+  self:HideAllText()
+end
+
+function Interface:ClearInterface()
+  self:StopBanner(InterfaceFrame.banner)
+  self:ClearWinInfo()
+end
+
+function Interface:ShowWinInfo()
+  if NS.IS_TEMPLE == false then
+    self:ShowInfo(InterfaceFrame.info)
+  end
+  self:ShowAllText()
 end
 
 function Interface:UpdateFinalScore(bar, aScore, hScore)
@@ -241,8 +282,11 @@ function Interface:InitializeInterface()
   NS.Interface.frame = InterfaceFrame
 end
 
-function Interface:CreateTestInfo()
+function Interface:CreateTestBannerInfo()
   self:UpdateBanner(InterfaceFrame.banner, 1500, "LOSE", { r = 0, g = 0, b = 0 })
+end
+
+function Interface:CreateTestWinInfo()
   self:UpdateFinalScore(InterfaceFrame.score, 1500, 800)
   self:UpdateInfo(InterfaceFrame.info, 1500, {
     [4] = {
@@ -270,4 +314,10 @@ function Interface:CreateTestInfo()
   })
   self:UpdateBuff(InterfaceFrame.buff, NS.ORB_BUFF_TIME, NS.formatTeamName(NS.PLAYER_FACTION, NS.PLAYER_FACTION))
   self:UpdateFlagValue(InterfaceFrame.flag, NS.formatScore(NS.ALLIANCE_NAME, 85))
+  self:ShowWinInfo()
+end
+
+function Interface:CreateTestInfo()
+  self:CreateTestBannerInfo()
+  self:CreateTestWinInfo()
 end

--- a/modules/Interface.lua
+++ b/modules/Interface.lua
@@ -105,11 +105,11 @@ function Interface:UpdateText(bar, txt)
 end
 
 function Interface:Hide(bar)
-  bar:Hide()
+  bar:SetAlpha(0)
 end
 
 function Interface:Show(bar)
-  bar:Show()
+  bar:SetAlpha(1)
 end
 
 function Interface:ClearAllText()
@@ -135,6 +135,9 @@ end
 
 function Interface:HideWinInfo()
   self:HideInfo(InterfaceFrame.info)
+  if NS.IN_GAME == false then
+    self:HideInfo(InterfaceFrame.buff)
+  end
   self:HideAllText()
 end
 
@@ -146,6 +149,9 @@ end
 function Interface:ShowWinInfo()
   if NS.IS_TEMPLE == false then
     self:ShowInfo(InterfaceFrame.info)
+  end
+  if NS.IN_GAME == false then
+    self:ShowInfo(InterfaceFrame.buff)
   end
   self:ShowAllText()
 end

--- a/modules/info.lua
+++ b/modules/info.lua
@@ -9,12 +9,18 @@ InfoFrame:SetScript("OnEvent", function(self, event, ...)
 end)
 
 local pairs = pairs
+local ipairs = ipairs
+local GetTime = GetTime
+local next = next
+local type = type
 
 local sformat = string.format
 local mmin = math.min
 local mmax = math.max
 local mceil = math.ceil
 local mfloor = math.floor
+local tinsert = table.insert
+local tsort = table.sort
 
 local Timer = C_Timer.After
 local GetAreaPOIInfo = C_AreaPoiInfo.GetAreaPOIInfo
@@ -453,11 +459,11 @@ do
             local allianceTimersSorted = {}
             for key, value in pairs(allyTimers) do
               if value and value - GetTime() > 0 then
-                table.insert(allianceTimersSorted, key)
+                tinsert(allianceTimersSorted, key)
               end
             end
             if #allianceTimersSorted > 1 then
-              table.sort(allianceTimersSorted, function(a, b)
+              tsort(allianceTimersSorted, function(a, b)
                 return allyTimers[a] - GetTime() < allyTimers[b] - GetTime()
               end)
             end
@@ -485,11 +491,11 @@ do
             local hordeTimersSorted = {}
             for key, value in pairs(hordeTimers) do
               if value and value - GetTime() > 0 then
-                table.insert(hordeTimersSorted, key)
+                tinsert(hordeTimersSorted, key)
               end
             end
             if #hordeTimersSorted > 1 then
-              table.sort(hordeTimersSorted, function(a, b)
+              tsort(hordeTimersSorted, function(a, b)
                 return hordeTimers[a] - GetTime() < hordeTimers[b] - GetTime()
               end)
             end

--- a/modules/options.lua
+++ b/modules/options.lua
@@ -4,6 +4,8 @@ local Interface = NS.Interface
 local Options = {}
 NS.Options = Options
 
+local INTERFACE_CLEARED = false
+
 local next = next
 local CreateFrame = CreateFrame
 
@@ -25,15 +27,12 @@ end
 local function updateBanner(value)
   if Interface.frame then
     if value then
-      if NS.IN_GAME == false then
-        Interface:ClearWinInfo()
-      else
-        Interface:HideWinInfo()
-      end
+      Interface:HideWinInfo()
     else
-      if NS.IN_GAME == false then
+      if INTERFACE_CLEARED then
         if NS.db.test then
           Interface:CreateTestInfo()
+          INTERFACE_CLEARED = false
         end
       else
         Interface:ShowWinInfo()
@@ -54,6 +53,7 @@ local function updateTestInfo(value)
       end
     else
       if NS.IN_GAME == false then
+        INTERFACE_CLEARED = true
         Interface:ClearInterface()
       end
     end

--- a/modules/options.lua
+++ b/modules/options.lua
@@ -4,6 +4,9 @@ local Interface = NS.Interface
 local Options = {}
 NS.Options = Options
 
+local next = next
+local CreateFrame = CreateFrame
+
 function Options:InitDB()
   BGWCDB = BGWCDB and next(BGWCDB) ~= nil and BGWCDB or {}
 
@@ -19,12 +22,40 @@ function Options:InitDB()
   NS.CleanupDB(BGWCDB, NS.DEFAULT_SETTINGS)
 end
 
+local function updateBanner(value)
+  if Interface.frame then
+    if value then
+      if NS.IN_GAME == false then
+        Interface:ClearWinInfo()
+      else
+        Interface:HideWinInfo()
+      end
+    else
+      if NS.IN_GAME == false then
+        if NS.db.test then
+          Interface:CreateTestInfo()
+        end
+      else
+        Interface:ShowWinInfo()
+      end
+    end
+  end
+end
+
 local function updateTestInfo(value)
   if Interface.frame then
     if value then
-      Interface:CreateTestInfo()
+      if NS.IN_GAME == false then
+        if NS.db.banner then
+          Interface:CreateTestBannerInfo()
+        else
+          Interface:CreateTestInfo()
+        end
+      end
     else
-      Interface:ClearInterface()
+      if NS.IN_GAME == false then
+        Interface:ClearInterface()
+      end
     end
   end
 end
@@ -76,8 +107,11 @@ function Options:InitializeOptions()
   local cb_test = self:CreateCheckbox("test", "Show placeholder info", self.panel_main, updateTestInfo)
   cb_test:SetPoint("TOPLEFT", cb_lock, 0, -30)
 
+  local cb_banner = self:CreateCheckbox("banner", "Show banner only", self.panel_main, updateBanner)
+  cb_banner:SetPoint("TOPLEFT", cb_test, 0, -30)
+
   local btn_reset = CreateFrame("Button", nil, self.panel_main, "UIPanelButtonTemplate")
-  btn_reset:SetPoint("TOPLEFT", cb_test, 0, -40)
+  btn_reset:SetPoint("TOPLEFT", cb_banner, 0, -40)
   btn_reset:SetText(RESET)
   btn_reset:SetWidth(100)
   btn_reset:SetScript("OnClick", function()


### PR DESCRIPTION
Adds a new user option to be able to only show the Win Banner if desired, this only applies to maps that use this which is basically everything except Temple of Kotmogu.

- providing an option to be able to only show the win banner if desired
- abstracting out all global functions and utils possible to local vars for performance