### PR TITLE
v9.3.21 - Various fixes based on recent testing

### DIFF
--- a/BattlegroundWinConditions.toc
+++ b/BattlegroundWinConditions.toc
@@ -1,6 +1,6 @@
 ## Interface: 100206
 ## Title: BattlegroundWinConditions
-## Version: 9.3.20
+## Version: 9.3.21
 ## Author: Ajax
 ## Notes: Provides real time win conditions for battlegrounds
 ## OptionalDeps: Ace3, LibStub, LibSharedMedia-3.0, AceGUI-3.0-SharedMediaWidgets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   - Removes the arena opponent api checks as they're unreliable and fire at times not just when someone picks
   - Fixes resetting the stack timer if the flag drops and someone else picks
   - Better ensures you're only tracking flag carriers and resetting only when needed
+  - Falls back to timer based stacks when dead since UNIT_AURA doesn't track enemies while dead
 - Adjusts the time to win on base maps when capping the first base or just a single base in general, time is now banner win time
 - Enables the debuff info on flag map info incase people haven't seen that option yet
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Battleground Win Conditions
 
+## [v9.3.21](https://github.com/rbgdevx/battleground-win-conditions/releases/tag/v9.3.21) (2024-04-18)
+
+- Fixes incorrect stack syncing on flag maps
+  - Removes the arena opponent api checks as they're unreliable and fire at times not just when someone picks
+  - Fixes resetting the stack timer if the flag drops and someone else picks
+  - Better ensures you're only tracking flag carriers and resetting only when needed
+- Adjusts the time to win on base maps when capping the first base or just a single base in general, time is now banner win time
+- Enables the debuff info on flag map info incase people haven't seen that option yet
+
 ## [v9.3.20](https://github.com/rbgdevx/battleground-win-conditions/releases/tag/v9.3.20) (2024-04-07)
 
 - Fixing slash commands

--- a/core/config.lua
+++ b/core/config.lua
@@ -193,11 +193,11 @@ NS.DefaultDatabase = {
       },
       twinpeaks = {
         enabled = true,
-        showdebuffinfo = false,
+        showdebuffinfo = true,
       },
       warsonggulch = {
         enabled = true,
-        showdebuffinfo = false,
+        showdebuffinfo = true,
       },
     },
     position = {

--- a/core/config.lua
+++ b/core/config.lua
@@ -117,7 +117,7 @@ NS.userClassHexColor = "|c" .. select(4, GetClassColor(NS.userClass))
 
 NS.ADDON_PREFIX = "BGWC_VERSION"
 NS.FoundNewVersion = false
-NS.VERSION = 9320
+NS.VERSION = 9321
 
 NS.DefaultDatabase = {
   global = {

--- a/core/helpers.lua
+++ b/core/helpers.lua
@@ -270,6 +270,13 @@ NS.checkWinCondition = function(
         --]]
         ownScore = ownScore,
         --[[
+        -- we need to subtract the gap score from the score
+        -- you need to get the base by because we were just looking
+        -- ahead to see had you got that base would you win
+        -- so this is that score you need prior to having a gap to be had
+        --]]
+        capScore = capScore,
+        --[[
         -- we need add the pending time of the current incoming
         -- bases since they actually haven't capped over yet
         --]]
@@ -280,12 +287,10 @@ NS.checkWinCondition = function(
         --]]
         capTime = capTime + GetTime(),
         --[[
-        -- we need to subtract the gap score from the score
-        -- you need to get the base by because we were just looking
-        -- ahead to see had you got that base would you win
-        -- so this is that score you need prior to having a gap to be had
+        -- we need to accomodate for the assault time to get by this time
+        -- as well as the cap time
         --]]
-        capScore = capScore,
+        winTime = mmin(mmax(0, oldWinTime), 1500) + GetTime(),
         minBases = minBases,
         maxBases = maxBases,
         winName = winName,

--- a/core/interface.lua
+++ b/core/interface.lua
@@ -89,6 +89,7 @@ function Interface:CreateTestInfo()
     [4] = {
       bases = 4,
       ownScore = 1299,
+      winTime = 800 + GetTime(),
       ownTime = 800 + GetTime(),
       capTime = 800 - NS.ASSAULT_TIME + GetTime(),
       capScore = 1299 - NS.ASSAULT_TIME * 2,
@@ -100,6 +101,7 @@ function Interface:CreateTestInfo()
     [5] = {
       bases = 5,
       ownScore = 1499,
+      winTime = 400 + GetTime(),
       ownTime = 400 + GetTime(),
       capTime = 400 - NS.ASSAULT_TIME + GetTime(),
       capScore = 1499 - NS.ASSAULT_TIME * 2,

--- a/interface/bases.lua
+++ b/interface/bases.lua
@@ -49,6 +49,7 @@ function Bases:Stop(frame, animationGroup)
 end
 
 local function winMessage(text, winCondition)
+  local winTime = winCondition.winTime - GetTime()
   local ownTime = winCondition.ownTime - GetTime()
   local winName = winCondition.winName
   local winMinBases = winCondition.minBases
@@ -61,7 +62,7 @@ local function winMessage(text, winCondition)
     message = sformat("%s win with %d right now\n", NS.formatTeamName(winName, NS.PLAYER_FACTION), winMinBases)
 
     if winMinBases == 1 then
-      message = message .. sformat("Hold %d for %s to win\n", winMinBases, NS.formatTime(ownTime))
+      message = message .. sformat("Hold %d for %s to win\n", winMinBases, NS.formatTime(winTime))
     else
       message = message
         .. sformat("Hold %d for %s to win with %d\n", winMinBases, NS.formatTime(ownTime), maxWinMinBases)
@@ -107,7 +108,7 @@ local function animationUpdate(frame, winTable, animationGroup)
 
   if t >= frame.exp then
     animationGroup:Stop()
-  -- frame.text:Hide()
+    -- frame.text:Hide()
   else
     local time = frame.exp - t
     frame.remaining = time

--- a/interface/stacks.lua
+++ b/interface/stacks.lua
@@ -2,6 +2,7 @@ local AddonName, NS = ...
 
 local CreateFrame = CreateFrame
 local GetTime = GetTime
+local UnitIsDeadOrGhost = UnitIsDeadOrGhost
 
 local LSM = LibStub("LibSharedMedia-3.0")
 
@@ -119,9 +120,14 @@ local function animationUpdate(frame, stacks, animationGroup)
   local t = GetTime()
 
   if t >= frame.exp then
-    localStacks = localStacks + 1
-
-    Stacks:Start(NS.STACK_TIME, localStacks)
+    -- enemy auras dont update while dead so we fallback to timers
+    if NS.IN_GAME and UnitIsDeadOrGhost("player") == false then
+      animationGroup:Stop()
+      -- frame.text:Hide()
+    else
+      localStacks = localStacks + 1
+      Stacks:Start(NS.STACK_TIME, localStacks)
+    end
   else
     local time = frame.exp - t
     frame.remaining = time

--- a/predictions/bases.lua
+++ b/predictions/bases.lua
@@ -140,6 +140,8 @@ do
             Banner:Start(winTime, winText)
             Score:SetText(Score.text, finalAScore, finalHScore)
 
+            -- local currentWinbases = aWins and allyBases or hordeBases
+
             local winBases = aWins and allyBases or hordeBases
             local loseBases = aWins and hordeBases or allyBases
             local winScore = aWins and aScore or hScore
@@ -159,7 +161,7 @@ do
                 0,
                 maxBases,
                 maxScore,
-                currentWinTime,
+                winTime,
                 curTickRate,
                 curMapInfo.baseResources
               )
@@ -251,6 +253,7 @@ do
             local hfs = aWins and hFutureScore + (winTicks * hordeFutureIncrease) or maxScore
             local finalHScore = (hordeBases == 0 and hordeIncBases == 0) and hScore or hfs
 
+            -- local currentWinBases = aWins and allyBases or hordeBases
             local currentLoseBases = aWins and hordeBases or allyBases
 
             local winBases = aWins and newAllyBases or newHordeBases
@@ -279,7 +282,7 @@ do
                 winTimeIncrease,
                 maxBases,
                 maxScore,
-                currentWinTime,
+                winTime,
                 curTickRate,
                 curMapInfo.baseResources
               )


### PR DESCRIPTION
- Fixes incorrect stack syncing on flag maps
  - Removes the arena opponent api checks as they're unreliable and fire at times not just when someone picks
  - Fixes resetting the stack timer if the flag drops and someone else picks
  - Better ensures you're only tracking flag carriers and resetting only when needed
  - Falls back to timer based stacks when dead since UNIT_AURA doesn't track enemies while dead
- Adjusts the time to win on base maps when capping the first base or just a single base in general, time is now banner win time
- Enables the debuff info on flag map info incase people haven't seen that option yet