### PR TITLE
v9.5.10 - Latest round of bugs and refactors and updates

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -67,7 +67,8 @@
     "table",
     "C_UnitAuras",
     "UnitAura",
-    "RESET"
+    "RESET",
+    "AceGUIWidgetLSMlists"
   ],
   "stylua.targetReleaseVersion": "latest"
 }

--- a/BattlegroundWinConditions.toc
+++ b/BattlegroundWinConditions.toc
@@ -1,8 +1,8 @@
-## Interface: 100207
+## Interface: 110002
 ## Title: BattlegroundWinConditions
-## Version: 9.4.22
-## Author: Ajax
-## Notes: Provides real time win conditions for battlegrounds
+## Version: 9.5.10
+## Author: RBGDEV
+## Notes: Real time win conditions for battlegrounds
 ## OptionalDeps: Ace3, LibStub, LibSharedMedia-3.0, AceGUI-3.0-SharedMediaWidgets
 ## IconTexture: Interface\AddOns\BattlegroundWinConditions\logo.tga
 ## SavedVariables: BattlegroundWinConditionsDB

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Battleground Win Conditions
 
+## [v9.5.0](https://github.com/rbgdevx/battleground-win-conditions/releases/tag/v9.5.0) (2024-08-01)
+
+- Lib updates
+- TOC updates
+- Refactor of the Win Conditions algorithm and incoming base info to be fully tick based and not time based which has TIE game implications and should provide more accurate results
+- Updating the placeholder text win condition info
+- Adds check upon joining game to ensure you're not in an 8v8 blitz mode game since that will have its own code and or addon
+- Simplifying win/lose text on banner upon timer expiring
+- Adding various win condition text info to help the user know in tricky situations what the loser wins with or not
+- Adding simplified lose text upon timer expiring
+- Refactor win condition table to only grab first win condition for performance reasons since bases can change all the time we dont need to process and store all future conditions if they never get used for the most part
+- Triggering win condition prediction upon first win condition timer expiring based on new refactor
+- Fixing flag map stack issues resseting after droping then someone else picking up while stacks are counting
+- Moving all flag stack logic to pvp channel messages instead of arena updates apis for consistency and reliability
+
 ## [v9.4.22](https://github.com/rbgdevx/battleground-win-conditions/releases/tag/v9.4.22) (2024-05-12)
 
 - Fixing text anchor from not being set correctly after Temple of Kotmogu

--- a/core/config.lua
+++ b/core/config.lua
@@ -105,8 +105,15 @@ NS.WIN_NOUN = "You"
 NS.LOSE_NOUN = "They"
 NS.ASSAULT_TIME = 6
 NS.CONTESTED_TIME = 60
+NS.ACTIVE_BASE_COUNT = 0
+NS.INCOMING_BASE_COUNT = 0
+NS.WIN_INC_BASE_COUNT = 0
 NS.ORB_BUFF_TIME = 45
 NS.STACK_TIME = 30
+NS.CURRENT_STACKS = 0
+NS.BASE_TIMER_EXPIRED = false
+NS.STACKS_COUNTING = false
+NS.HAS_FLAG_CARRIER = false
 NS.IN_GAME = false
 NS.IS_TEMPLE = false
 NS.IS_EOTS = false
@@ -119,7 +126,7 @@ NS.userClassHexColor = "|c" .. select(4, GetClassColor(NS.userClass))
 
 NS.ADDON_PREFIX = "BGWC_VERSION"
 NS.FoundNewVersion = false
-NS.VERSION = 9422
+NS.VERSION = 9510
 
 NS.DefaultDatabase = {
   global = {

--- a/core/interface.lua
+++ b/core/interface.lua
@@ -1,6 +1,7 @@
 local _, NS = ...
 
 local ipairs = ipairs
+local mceil = math.ceil
 
 local Anchor = NS.Anchor
 local Banner = NS.Banner
@@ -80,38 +81,65 @@ function Interface:Refresh()
 end
 
 function Interface:CreateTestBanner()
-  Banner:Start(1500, "TIE")
+  Banner:Start(434, "TIE")
 end
 
 function Interface:CreateTestInfo()
   Info:SetAnchor(Banner.frame, 0, 0)
   Info:Start()
 
-  Score:SetText(Score.text, 1500, 1500)
-  Bases:Start(1500, {
+  Score:SetText(Score.text, 1500, 1125)
+  Bases:Start(434, {
+    [3] = {
+      bases = 3,
+      ownScore = 1081,
+      winTime = 434 + GetTime(),
+      winTicks = mceil(434 / 2),
+      ownTime = 224 + GetTime(),
+      ownTicks = mceil(224 / 2),
+      capTime = 218 + GetTime(),
+      capTicks = mceil(218 / 2),
+      capScore = 1069,
+      minBases = 3,
+      maxBases = 5,
+      winName = NS.PLAYER_FACTION,
+      loseName = NS.PLAYER_FACTION == NS.ALLIANCE_NAME and NS.HORDE_NAME or NS.ALLIANCE_NAME,
+      loseBases = 2,
+      tickRate = 2,
+    },
     [4] = {
       bases = 4,
-      ownScore = 1299,
-      winTime = 800 + GetTime(),
-      ownTime = 800 + GetTime(),
-      capTime = 800 - NS.ASSAULT_TIME + GetTime(),
-      capScore = 1299 - NS.ASSAULT_TIME * 2,
+      ownScore = 1377,
+      winTime = 434 + GetTime(),
+      winTicks = mceil(434 / 2),
+      ownTime = 372 + GetTime(),
+      ownTicks = mceil(372 / 2),
+      capTime = 366 + GetTime(),
+      capTicks = mceil(366 / 2),
+      capScore = 1365,
       minBases = 2,
       maxBases = 5,
       winName = NS.PLAYER_FACTION,
       loseName = NS.PLAYER_FACTION == NS.ALLIANCE_NAME and NS.HORDE_NAME or NS.ALLIANCE_NAME,
+      loseBases = 2,
+      tickRate = 2,
     },
     [5] = {
       bases = 5,
-      ownScore = 1499,
-      winTime = 400 + GetTime(),
-      ownTime = 400 + GetTime(),
-      capTime = 400 - NS.ASSAULT_TIME + GetTime(),
-      capScore = 1499 - NS.ASSAULT_TIME * 2,
+      ownScore = 1497,
+      winTime = 434 + GetTime(),
+      winTicks = mceil(434 / 2),
+      ownTime = 432 + GetTime(),
+      ownTicks = mceil(432 / 2),
+      capTime = 426 + GetTime(),
+      capTicks = mceil(426 / 2),
+      capScore = 1485,
       minBases = 1,
       maxBases = 5,
       winName = NS.PLAYER_FACTION,
       loseName = NS.PLAYER_FACTION == NS.ALLIANCE_NAME and NS.HORDE_NAME or NS.ALLIANCE_NAME,
+      loseBases = 2,
+      tickRate = 2,
     },
   })
 

--- a/core/maps.lua
+++ b/core/maps.lua
@@ -3,6 +3,7 @@ local _, NS = ...
 local select = select
 local IsInInstance = IsInInstance
 local GetInstanceInfo = GetInstanceInfo
+local GetNumGroupMembers = GetNumGroupMembers
 
 local After = C_Timer.After
 
@@ -85,7 +86,12 @@ do
       local instanceID = select(8, GetInstanceInfo())
       if zoneIds[instanceID] then
         After(5, function()
-          Maps:EnableZone(instanceID)
+          local maxPlayers = select(5, GetInstanceInfo())
+          local groupSize = GetNumGroupMembers()
+
+          if maxPlayers == 0 or groupSize == 0 or maxPlayers >= 10 or groupSize > 8 then
+            Maps:EnableZone(instanceID)
+          end
         end)
       end
     end

--- a/interface/banner.lua
+++ b/interface/banner.lua
@@ -56,16 +56,23 @@ function Banner:Stop(frame, animationGroup)
 end
 
 local bannerformat = "GG YOU %s IN %s"
-
+local bannerformatWin = "GG YOU %s"
 local function animationUpdate(frame, text, animationGroup)
   local t = GetTime()
+
   if t >= frame.exp then
+    Banner:SetText(frame.text, bannerformatWin, text)
     animationGroup:Stop()
     -- frame.text:Hide()
   else
     local time = frame.exp - t
     frame.remaining = time
-    Banner:SetText(frame.text, bannerformat, text, NS.formatTime(time))
+
+    if time <= 0 then
+      Banner:SetText(frame.text, bannerformatWin, text)
+    else
+      Banner:SetText(frame.text, bannerformat, text, NS.formatTime(time))
+    end
     -- frame.text:Show()
   end
 end

--- a/interface/stacks.lua
+++ b/interface/stacks.lua
@@ -151,13 +151,21 @@ local function animationUpdate(frame, stacks, animationGroup)
   local t = GetTime()
 
   if t >= frame.exp then
-    -- enemy auras dont update while dead so we fallback to timers
-    if NS.IN_GAME and UnitIsDeadOrGhost("player") == false then
+    -- fallback to timers:
+    -- if we aren't in a game
+    -- enemy auras dont update while dead
+    -- auras dont get tracked if nobody is carrying the flag but stacks are still counting
+    if
+      NS.IN_GAME == false
+      or (NS.IN_GAME and UnitIsDeadOrGhost("player"))
+      or (NS.IN_GAME and NS.STACKS_COUNTING and NS.HAS_FLAG_CARRIER == false)
+    then
+      localStacks = localStacks + 1
+      NS.CURRENT_STACKS = localStacks
+      Stacks:Start(NS.STACK_TIME, localStacks)
+    else
       animationGroup:Stop()
       -- frame.text:Hide()
-    else
-      localStacks = localStacks + 1
-      Stacks:Start(NS.STACK_TIME, localStacks)
     end
   else
     local time = frame.exp - t

--- a/libs/AceConfig-3.0/AceConfig-3.0.lua
+++ b/libs/AceConfig-3.0/AceConfig-3.0.lua
@@ -3,7 +3,7 @@
 -- as well as associate it with a slash command.
 -- @class file
 -- @name AceConfig-3.0
--- @release $Id: AceConfig-3.0.lua 1202 2019-05-15 23:11:22Z nevcairiel $
+-- @release $Id: AceConfig-3.0.lua 1335 2024-05-05 19:35:16Z nevcairiel $
 
 --[[
 AceConfig-3.0
@@ -27,7 +27,7 @@ if not AceConfig then return end
 local pcall, error, type, pairs = pcall, error, type, pairs
 
 -- -------------------------------------------------------------------
--- :RegisterOptionsTable(appName, options, slashcmd, persist)
+-- :RegisterOptionsTable(appName, options, slashcmd)
 --
 -- - appName - (string) application name
 -- - options - table or function ref, see AceConfigRegistry

--- a/libs/AceGUI-3.0/widgets/AceGUIWidget-ColorPicker.lua
+++ b/libs/AceGUI-3.0/widgets/AceGUIWidget-ColorPicker.lua
@@ -1,7 +1,7 @@
 --[[-----------------------------------------------------------------------------
 ColorPicker Widget
 -------------------------------------------------------------------------------]]
-local Type, Version = "ColorPicker", 25
+local Type, Version = "ColorPicker", 28
 local AceGUI = LibStub and LibStub("AceGUI-3.0", true)
 if not AceGUI or (AceGUI:GetWidgetVersion(Type) or 0) >= Version then return end
 
@@ -11,12 +11,23 @@ local pairs = pairs
 -- WoW APIs
 local CreateFrame, UIParent = CreateFrame, UIParent
 
+-- Unfortunately we have no way to realistically detect if a client uses inverted alpha
+-- as no API will tell you. Wrath uses the old colorpicker, era uses the new one, both are inverted
+local INVERTED_ALPHA = (WOW_PROJECT_ID ~= WOW_PROJECT_MAINLINE)
+
 --[[-----------------------------------------------------------------------------
 Support functions
 -------------------------------------------------------------------------------]]
 local function ColorCallback(self, r, g, b, a, isAlpha)
+	if INVERTED_ALPHA and a then
+		a = 1 - a
+	end
 	if not self.HasAlpha then
 		a = 1
+	end
+	-- no change, skip update
+	if r == self.r and g == self.g and b == self.b and a == self.a then
+		return
 	end
 	self:SetColor(r, g, b, a)
 	if ColorPickerFrame:IsVisible() then
@@ -50,30 +61,63 @@ local function ColorSwatch_OnClick(frame)
 		ColorPickerFrame:SetFrameLevel(frame:GetFrameLevel() + 10)
 		ColorPickerFrame:SetClampedToScreen(true)
 
-		ColorPickerFrame.func = function()
-			local r, g, b = ColorPickerFrame:GetColorRGB()
-			local a = 1 - OpacitySliderFrame:GetValue()
-			ColorCallback(self, r, g, b, a)
-		end
+		if ColorPickerFrame.SetupColorPickerAndShow then -- 10.2.5 color picker overhaul
+			local r2, g2, b2, a2 = self.r, self.g, self.b, (self.a or 1)
+			if INVERTED_ALPHA then
+				a2 = 1 - a2
+			end
 
-		ColorPickerFrame.hasOpacity = self.HasAlpha
-		ColorPickerFrame.opacityFunc = function()
-			local r, g, b = ColorPickerFrame:GetColorRGB()
-			local a = 1 - OpacitySliderFrame:GetValue()
-			ColorCallback(self, r, g, b, a, true)
-		end
+			local info = {
+				swatchFunc = function()
+					local r, g, b = ColorPickerFrame:GetColorRGB()
+					local a = ColorPickerFrame:GetColorAlpha()
+					ColorCallback(self, r, g, b, a)
+				end,
 
-		local r, g, b, a = self.r, self.g, self.b, self.a
-		if self.HasAlpha then
-			ColorPickerFrame.opacity = 1 - (a or 0)
-		end
-		ColorPickerFrame:SetColorRGB(r, g, b)
+				hasOpacity = self.HasAlpha,
+				opacityFunc = function()
+					local r, g, b = ColorPickerFrame:GetColorRGB()
+					local a = ColorPickerFrame:GetColorAlpha()
+					ColorCallback(self, r, g, b, a, true)
+				end,
+				opacity = a2,
 
-		ColorPickerFrame.cancelFunc = function()
-			ColorCallback(self, r, g, b, a, true)
-		end
+				cancelFunc = function()
+					ColorCallback(self, r2, g2, b2, a2, true)
+				end,
 
-		ColorPickerFrame:Show()
+				r = r2,
+				g = g2,
+				b = b2,
+			}
+
+			ColorPickerFrame:SetupColorPickerAndShow(info)
+		else
+			ColorPickerFrame.func = function()
+				local r, g, b = ColorPickerFrame:GetColorRGB()
+				local a = OpacitySliderFrame:GetValue()
+				ColorCallback(self, r, g, b, a)
+			end
+
+			ColorPickerFrame.hasOpacity = self.HasAlpha
+			ColorPickerFrame.opacityFunc = function()
+				local r, g, b = ColorPickerFrame:GetColorRGB()
+				local a = OpacitySliderFrame:GetValue()
+				ColorCallback(self, r, g, b, a, true)
+			end
+
+			local r, g, b, a = self.r, self.g, self.b, 1 - (self.a or 1)
+			if self.HasAlpha then
+				ColorPickerFrame.opacity = a
+			end
+			ColorPickerFrame:SetColorRGB(r, g, b)
+
+			ColorPickerFrame.cancelFunc = function()
+				ColorCallback(self, r, g, b, a, true)
+			end
+
+			ColorPickerFrame:Show()
+		end
 	end
 	AceGUI:ClearFocus()
 end

--- a/libs/AceGUI-3.0/widgets/AceGUIWidget-EditBox.lua
+++ b/libs/AceGUI-3.0/widgets/AceGUIWidget-EditBox.lua
@@ -1,7 +1,7 @@
 --[[-----------------------------------------------------------------------------
 EditBox Widget
 -------------------------------------------------------------------------------]]
-local Type, Version = "EditBox", 28
+local Type, Version = "EditBox", 29
 local AceGUI = LibStub and LibStub("AceGUI-3.0", true)
 if not AceGUI or (AceGUI:GetWidgetVersion(Type) or 0) >= Version then return end
 
@@ -10,7 +10,7 @@ local tostring, pairs = tostring, pairs
 
 -- WoW APIs
 local PlaySound = PlaySound
-local GetCursorInfo, ClearCursor, GetSpellInfo = GetCursorInfo, ClearCursor, GetSpellInfo
+local GetCursorInfo, ClearCursor = GetCursorInfo, ClearCursor
 local CreateFrame, UIParent = CreateFrame, UIParent
 local _G = _G
 
@@ -76,12 +76,16 @@ end
 
 local function EditBox_OnReceiveDrag(frame)
 	local self = frame.obj
-	local type, id, info = GetCursorInfo()
+	local type, id, info, extra = GetCursorInfo()
 	local name
 	if type == "item" then
 		name = info
 	elseif type == "spell" then
-		name = GetSpellInfo(id, info)
+		if C_Spell and C_Spell.GetSpellName then
+			name = C_Spell.GetSpellName(extra)
+		else
+			name = GetSpellInfo(id, info)
+		end
 	elseif type == "macro" then
 		name = GetMacroInfo(id)
 	end

--- a/libs/AceGUI-3.0/widgets/AceGUIWidget-MultiLineEditBox.lua
+++ b/libs/AceGUI-3.0/widgets/AceGUIWidget-MultiLineEditBox.lua
@@ -1,4 +1,4 @@
-local Type, Version = "MultiLineEditBox", 32
+local Type, Version = "MultiLineEditBox", 33
 local AceGUI = LibStub and LibStub("AceGUI-3.0", true)
 if not AceGUI or (AceGUI:GetWidgetVersion(Type) or 0) >= Version then return end
 
@@ -6,7 +6,7 @@ if not AceGUI or (AceGUI:GetWidgetVersion(Type) or 0) >= Version then return end
 local pairs = pairs
 
 -- WoW APIs
-local GetCursorInfo, GetSpellInfo, ClearCursor = GetCursorInfo, GetSpellInfo, ClearCursor
+local GetCursorInfo, ClearCursor = GetCursorInfo, ClearCursor
 local CreateFrame, UIParent = CreateFrame, UIParent
 local _G = _G
 
@@ -100,9 +100,13 @@ local function OnMouseUp(self)                                                  
 end
 
 local function OnReceiveDrag(self)                                               -- EditBox / ScrollFrame
-	local type, id, info = GetCursorInfo()
+	local type, id, info, extra = GetCursorInfo()
 	if type == "spell" then
-		info = GetSpellInfo(id, info)
+		if C_Spell and C_Spell.GetSpellName then
+			info = C_Spell.GetSpellName(extra)
+		else
+			info = GetSpellInfo(id, info)
+		end
 	elseif type ~= "item" then
 		return
 	end

--- a/libs/LibSharedMedia-3.0/LibSharedMedia-3.0.lua
+++ b/libs/LibSharedMedia-3.0/LibSharedMedia-3.0.lua
@@ -1,7 +1,7 @@
 --@curseforge-project-slug: libsharedmedia-3-0@
 --[[
 Name: LibSharedMedia-3.0
-Revision: $Revision: 128 $
+Revision: $Revision: 151 $
 Author: Elkano (elkano@gmx.de)
 Inspired By: SurfaceLib by Haste/Otravi (troeks@gmail.com)
 Website: http://www.wowace.com/projects/libsharedmedia-3-0/
@@ -23,11 +23,9 @@ local type		= _G.type
 local band			= _G.bit.band
 local table_sort	= _G.table.sort
 
-local RESTRICTED_FILE_ACCESS = WOW_PROJECT_ID == WOW_PROJECT_MAINLINE -- starting with 8.2, some rules for file access have changed; classic still uses the old way
-
 local locale = GetLocale()
 local locale_is_western
-local LOCALE_MASK = 0
+local LOCALE_MASK
 lib.LOCALE_BIT_koKR		= 1
 lib.LOCALE_BIT_ruRU		= 2
 lib.LOCALE_BIT_zhCN		= 4
@@ -199,7 +197,7 @@ lib.DefaultMedia.statusbar = "Blizzard"
 
 -- SOUND
 if not lib.MediaTable.sound then lib.MediaTable.sound = {} end
-lib.MediaTable.sound["None"]		= RESTRICTED_FILE_ACCESS and 1 or [[Interface\Quiet.ogg]] -- Relies on the fact that PlaySound[File] doesn't error on these values.
+lib.MediaTable.sound["None"] = 1 -- Relies on the fact that PlaySoundFile doesn't error on this value
 lib.DefaultMedia.sound = "None"
 
 local function rebuildMediaList(mediatype)
@@ -230,7 +228,7 @@ function lib:Register(mediatype, key, data, langmask)
 	end
 	if type(data) == "string" and (mediatype == lib.MediaType.BACKGROUND or mediatype == lib.MediaType.BORDER or mediatype == lib.MediaType.STATUSBAR or mediatype == lib.MediaType.SOUND) then
 		local path = data:lower()
-		if RESTRICTED_FILE_ACCESS and not path:find("^interface") then
+		if not path:find("^interface") then
 			-- files accessed via path only allowed from interface folder
 			return false
 		end


### PR DESCRIPTION
- Lib updates
- TOC updates
- Refactor of the Win Conditions algorithm and incoming base info to be fully tick based and not time based which has TIE game implications and should provide more accurate results
- Updating the placeholder text win condition info
- Adds check upon joining game to ensure you're not in an 8v8 blitz mode game since that will have its own code and or addon
- Simplifying win/lose text on banner upon timer expiring
- Adding various win condition text info to help the user know in tricky situations what the loser wins with or not
- Adding simplified lose text upon timer expiring
- Refactor win condition table to only grab first win condition for performance reasons since bases can change all the time we dont need to process and store all future conditions if they never get used for the most part
- Triggering win condition prediction upon first win condition timer expiring based on new refactor
- Fixing flag map stack issues resseting after droping then someone else picking up while stacks are counting
- Moving all flag stack logic to pvp channel messages instead of arena updates apis for consistency and reliability