### PR TITLE
Map controller updates and cleanup

### DIFF
--- a/BattlegroundWinConditions.toc
+++ b/BattlegroundWinConditions.toc
@@ -1,13 +1,12 @@
-## Interface: 110002
+## Interface: 110007
 ## Title: BattlegroundWinConditions
-## Version: 9.6.22
+## Version: 9.7.0
 ## Author: RBGDEV
 ## Notes: Real time win conditions for battlegrounds
-## OptionalDeps: Ace3, LibStub, LibSharedMedia-3.0, AceGUI-3.0-SharedMediaWidgets
+## OptionalDeps: AceConfig-3.0, AceGUI-3.0, AceGUI-3.0-SharedMediaWidgets, CallbackHandler-1.0, LibChangelog, LibSharedMedia-3.0, LibStub
 ## IconTexture: Interface\AddOns\BattlegroundWinConditions\logo.tga
 ## SavedVariables: BattlegroundWinConditionsDB
 ## X-Category: Battlegrounds/PvP
-## X-Credits: Ajax
 ## X-License: All Rights Reserved
 ## X-Website: https://www.curseforge.com/wow/addons/battleground-win-conditions
 ## X-Curse-Project-ID: 932307
@@ -21,6 +20,7 @@ embeds.xml
 core/config.lua
 core/helpers.lua
 core/version.lua
+core/changelog.lua
 interface/anchor.lua
 interface/banner.lua
 interface/info.lua
@@ -36,6 +36,7 @@ predictions/carts.lua
 predictions/flags.lua
 predictions/orbs.lua
 maps/ArathiBasin.lua
+maps/DeephaulRavine.lua
 maps/DeepwindGorge.lua
 maps/EyeoftheStorm.lua
 maps/SilvershardMines.lua

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Battleground Win Conditions
 
+## [v9.7.0](https://github.com/rbgdevx/battleground-win-conditions/releases/tag/v9.7.0) (2024-12-20)
+
+- Complete overhaul of map controller managing entering/exiting bgs and their state
+- Adding Deephaul Ravine to the list of maps, but not yet completed
+- New supporting helpers from event and state refactoring
+- Adding some additional conditional checks from recent testing and bugs
+- Map settings overhaul for all maps to create common configs for easy switching between blitz and regular bgs
+- Leveraging blizzard api enums over hard coded values in conditionals
+- Using variables for max scores instead of hard coded values
+- Changing checks in base caps to proper conditional lua statements
+- Adding additional checks for win con triggers to include inc base changes not just point changes
+- Fixing base reset on blitz eots to always show correctly
+- Adding an additional check for flag caps to reset stacks
+- Reverting flag cap functions back to inline handling logic per battleground message
+- Adding early out on orbs if unit isn't a carrier
+- Updating db cleanup function to ignore lastReadVersion and lastFlagCapBy as those are set dynamically
+- New simplified interface start function
+- New changelog manager and dialog lib
+- Adding version check code
+- Drag and Click control updates to ensure click through when hidden or locked
+- Fixing font dropdown list
+- Updating font size range
+- Minor Cleanup
+- Update toc
+
 ## [v9.6.22](https://github.com/rbgdevx/battleground-win-conditions/releases/tag/v9.6.22) (2024-08-21)
 
 - Adding back in EOTS helper function to check if we're on EOTS

--- a/core/changelog.lua
+++ b/core/changelog.lua
@@ -2,6 +2,8 @@ local AddonName, NS = ...
 
 local LibStub = LibStub
 
+local LibChangelog = LibStub("LibChangelog")
+
 local Changelog = {}
 NS.Changelog = Changelog
 
@@ -505,6 +507,6 @@ local changelog = {
 }
 
 function Changelog:Setup()
-  LibStub("LibChangelog"):Register(AddonName, changelog, NS.db, "lastReadVersion", "onlyShowWhenNewVersion")
-  LibStub("LibChangelog"):ShowChangelog(AddonName)
+  LibChangelog:Register(AddonName, changelog, NS.db, "lastReadVersion", "onlyShowWhenNewVersion")
+  LibChangelog:ShowChangelog(AddonName)
 end

--- a/core/changelog.lua
+++ b/core/changelog.lua
@@ -1,0 +1,510 @@
+local AddonName, NS = ...
+
+local LibStub = LibStub
+
+local Changelog = {}
+NS.Changelog = Changelog
+
+local changelog = {
+  {
+    Version = "9.7.0",
+    General = "Major overhaul and cleanup",
+    Sections = {
+      {
+        Header = "Overhaul",
+        Entries = {
+          "Complete overhaul of map controller managing entering/exiting bgs and their state",
+          "New supporting helpers from event and state refactoring",
+          "Leveraging blizzard api enums over hard coded values in conditionals",
+          "Using variables for max scores instead of hard coded values",
+          "Reverting flag cap functions back to inline handling logic per battleground message",
+          "Adding early out on orbs if unit isn't a carrier",
+          "Map settings overhaul for all maps to create common configs for easy switching between blitz and regular bgs",
+          "Adding additional checks for win con triggers to include inc base changes not just point changes",
+        },
+      },
+      {
+        Header = "New Map Support",
+        Entries = {
+          "Adding Deephaul Ravine to the list of maps, but not yet completed",
+        },
+      },
+      {
+        Header = "General",
+        Entries = {
+          "New simplified interface start function",
+          "New changelog manager and dialog lib",
+          "Adding version check code",
+          "Minor Cleanup",
+          "Update toc",
+        },
+      },
+      {
+        Header = "Bugfixes",
+        Entries = {
+          "Adding some additional conditional checks from recent testing and bugs",
+          "Changing checks in base caps to proper conditional lua statements",
+          "Fixing base reset on blitz eots to always show correctly",
+          "Adding an additional check for flag caps to reset stacks",
+          "Updating db cleanup function to ignore lastReadVersion and lastFlagCapBy as those are set dynamically",
+          "Drag and Click control updates to ensure click through when hidden or locked",
+          "Fixing font dropdown list",
+          "Updating font size range",
+        },
+      },
+    },
+  },
+  {
+    Version = "9.6.22",
+    General = "Fixing various bugs",
+    Sections = {
+      {
+        Header = "Bugfixes",
+        Entries = {
+          "Adding back in EOTS helper function to check if we're on EOTS",
+          "Adding in a new debug feature to easily leave out prints when not debugging",
+          "Fixed group size check from wrong variable/api",
+          "Fixed faction setting by updating and adding placements for setting it upon entering a bg",
+          "Fixed load in game check when toggling zones in and out of instances",
+          "Updated flag cap check on base maps (EOTS) to remove old dwg check which no longer exists",
+        },
+      },
+    },
+  },
+  {
+    Version = "9.6.21",
+    General = "Adding eots blitz support",
+    Sections = {
+      {
+        Header = "EOTS Blitz Support",
+        Entries = {
+          "Adding EOTS Battleground Blitz mode support",
+          "NEW feature that shows reset timer in the banner after capping",
+        },
+      },
+      {
+        Header = "New setting",
+        Entries = {
+          "Added new setting for the new reset banner timer",
+          "Fixed being able to see your banner color changes real time",
+        },
+      },
+      {
+        Header = "General",
+        Entries = {
+          "Removed old helper functions",
+          "Fixed incorrect win time in info text when winning with 1 base",
+          "Added some null checks based on recent testing and bugs caught",
+          "Added new 'they can still win with' condition based on EOTS blitz testing",
+          "Adding failsafe for map zone toggle",
+          "Minor cleanup",
+        },
+      },
+    },
+  },
+  {
+    Version = "9.6.11",
+    General = "New TOK feature and start of blitz support",
+    Sections = {
+      {
+        Header = "Blitz Support",
+        Entries = {
+          "All new Battleground Blitz support for the following maps with EXISTING features:",
+          "The Battle for Gilneas",
+          "Twin Peaks",
+          "Warsong Gulch",
+        },
+      },
+      {
+        Header = "New TOK Feature",
+        Entries = {
+          "NEW Temple of Kotmogu feature that shows available orbs, and when an orb is taken it shows the damage taken increase percentage for that orb carrier",
+          "This new feature can be toggled on/off in the settings",
+        },
+      },
+      {
+        Header = "General",
+        Entries = {
+          "Lots of performance enhancements that aims to reduce and reuse duplicate code in loops and aura checking into helper functions",
+          "Updates the default font-size to 14",
+          "Prep work to add support for Battleground Blitz for the remaining maps",
+          "Minor cleanup and fixes",
+        },
+      },
+    },
+  },
+  {
+    Version = "9.5.10",
+    General = "Latest round of bugs and refactors and updates",
+    Sections = {
+      {
+        Header = "General",
+        Entries = {
+          "Lib updates",
+          "TOC updates",
+          "Refactor of the Win Conditions algorithm and incoming base info to be fully tick based and not time based which has TIE game implications and should provide more accurate results",
+          "Updating the placeholder text win condition info",
+          "Adds check upon joining game to ensure you're not in an 8v8 blitz mode game since that will have its own code and or addon",
+          "Simplifying win/lose text on banner upon timer expiring",
+          "Adding various win condition text info to help the user know in tricky situations what the loser wins with or not",
+          "Adding simplified lose text upon timer expiring",
+          "Refactor win condition table to only grab first win condition for performance reasons since bases can change all the time we don't need to process and store all future conditions if they never get used for the most part",
+          "Triggering win condition prediction upon first win condition timer expiring based on new refactor",
+          "Fixing flag map stack issues resetting after dropping then someone else picking up while stacks are counting",
+          "Moving all flag stack logic to pvp channel messages instead of arena updates apis for consistency and reliability",
+        },
+      },
+    },
+  },
+  {
+    Version = "9.4.22",
+    General = "Fixing text anchor",
+    Sections = {
+      {
+        Header = "General",
+        Entries = {
+          "Fixing text anchor from not being set correctly after Temple of Kotmogu",
+        },
+      },
+    },
+  },
+  {
+    Version = "9.4.21",
+    General = "New settings and setting bug fixes",
+    Sections = {
+      {
+        Header = "General",
+        Entries = {
+          "Added a new setting to be able to add a background to the info text",
+          "Added a new setting to be able to change the info text color",
+          "Added a new setting to be able to turn off Temple orb buff text",
+          "Added a new setting to be able to turn off flag map info on EOTS",
+          "Updated setting descriptions",
+          "Fixed various bugs with turning off and on settings and combinations of settings to hide/show properly",
+          "Fixing 10.2.7 bugs for incorrect setting of text justification",
+          "Updated some file names to better match their usage",
+          "Update toc",
+        },
+      },
+    },
+  },
+  {
+    Version = "9.3.21",
+    General = "Various fixes based on recent testing",
+    Sections = {
+      {
+        Header = "Fixes incorrect stack syncing on flag maps",
+        Entries = {
+          "Removes the arena opponent api checks as they're unreliable and fire at times not just when someone picks",
+          "Fixes resetting the stack timer if the flag drops and someone else picks",
+          "Better ensures you're only tracking flag carriers and resetting only when needed",
+          "Falls back to timer based stacks when dead since UNIT_AURA doesn't track enemies while dead",
+        },
+      },
+      {
+        Header = "General",
+        Entries = {
+          "Adjusts the time to win on base maps when capping the first base or just a single base in general, time is now banner win time",
+          "Enables the debuff info on flag map info incase people haven't seen that option yet",
+        },
+      },
+    },
+  },
+  {
+    Version = "9.3.20",
+    General = "Fixing flag map stack + removing base info minimum",
+    Sections = {
+      {
+        Header = "Bugfixes",
+        Entries = {
+          "Fixing slash commands",
+          "Removing flag cap maximum stacks since there is no more limit from what i found in recent testing",
+          "Removing the need for points on the board to see if you win or not in base maps, so now you can know immediately upon first cap",
+          "Fixing incorrect stack resetting based on arena frame updates since it's not reliable and has the ability to mess with stack counts",
+        },
+      },
+    },
+  },
+  {
+    Version = "9.3.19",
+    Sections = {
+      {
+        Header = "Bugfixes",
+        Entries = {
+          "Fixing eots flags needed calculation when ahead in points and bases",
+          "adding updated descriptions for individual map enabling toggles",
+          "always clearing interface upon joining new games",
+          "updating banner scale minimum",
+        },
+      },
+    },
+  },
+  {
+    Version = "9.3.18",
+    General = "Adding new option to settings",
+    Sections = {
+      {
+        Header = "General",
+        Entries = {
+          "Adding a new setting to turn off the GG Banner and only show the win text",
+          "Updated some setting descriptions and labels",
+          "Updating the minimums for banner scale and font size",
+        },
+      },
+    },
+  },
+  {
+    Version = "9.3.17",
+    Sections = {
+      {
+        Header = "Bugfixes",
+        Entries = {
+          "Fixing setting some vars once joining a game",
+        },
+      },
+    },
+  },
+  {
+    Version = "9.3.16",
+    General = "Major refactor for all new feature sets",
+    Sections = {
+      {
+        Header = "Complete overhaul of the settings options to include",
+        Entries = {
+          "Choosing your font size",
+          "Banner Scaling",
+          "Banner colors for TIE, WIN, LOSE",
+          "Enable or Disable by Map",
+          "Enable or Disable certain features on EOTS and Flag maps",
+        },
+      },
+      {
+        Header = "NEW flag map features",
+        Entries = {
+          "Shows a Next stack timer",
+          "Shows how many stacks are currently applied",
+          "Shows timer to 6 stacks",
+          "Shows healing received reduction %",
+          "Shows damage taken increase %",
+        },
+      },
+      {
+        Header = "NEW refactored EOTS flag text",
+        Entries = {
+          "Instead of showing the point value of a flag i now show how many flags you are either ahead or behind by so you know an additional win condition",
+        },
+      },
+      {
+        Header = "Performance improvements",
+        Entries = {
+          "amidst various random cleanup and refactor is now only the necessary code runs on certain maps reducing the amount of processing needed real time",
+        },
+      },
+      {
+        Header = "General",
+        Entries = {
+          "Refactored the win algorithm to be TICK based instead of TIME based to more accurately detect TIE games and reduce loops to run increasing performance",
+          "Win Timer bug fixes during incoming bases",
+        },
+      },
+    },
+  },
+  {
+    Version = "8.2.15",
+    Sections = {
+      {
+        Header = "Bugfixes",
+        Entries = {
+          "fixing bugs on eots",
+        },
+      },
+    },
+  },
+  {
+    Version = "8.2.14",
+    Sections = {
+      {
+        Header = "General",
+        Entries = {
+          "refactoring the predictor code to be its own function so it can be called on base update events and not just score updates",
+          "removing old unused code for cleanup",
+          "fixing a drag issue upon locking",
+        },
+      },
+    },
+  },
+  {
+    Version = "8.1.13",
+    Sections = {
+      {
+        Header = "Bugfixes",
+        Entries = {
+          "fixing potential win time algorithm",
+        },
+      },
+    },
+  },
+  {
+    Version = "8.1.12",
+    Sections = {
+      {
+        Header = "General",
+        Entries = {
+          "refactor update check to fix an issue where the it wasn't properly getting the the correct incoming base counts",
+        },
+      },
+    },
+  },
+  {
+    Version = "8.1.11",
+    Sections = {
+      {
+        Header = "General",
+        Entries = {
+          "updating implementation of new version handling",
+          "main file event re-order to remove hoisting",
+          "win info variable cleanup",
+          "update slash commands to all be toggle based",
+        },
+      },
+    },
+  },
+  {
+    Version = "8.1.10",
+    Sections = {
+      {
+        Header = "Bugfixes",
+        Entries = {
+          "fixing a bug where the enemy base timer wasn't getting reset when you got a base back them before it finished capping or if you stole a base from them mid-cap",
+        },
+      },
+    },
+  },
+  {
+    Version = "8.1.9",
+    General = "First major refactor",
+    Sections = {
+      {
+        Header = "General",
+        Entries = {
+          "fixing TIE game support",
+          "making sure you cant click the anchor when its set to hidden while locked",
+          "adding all new slash commands (see description for info)",
+          "major code cleanup on code warnings to make things as clean and performant as possible",
+          "refactoring some of the algorithm based on recent testing and bugs found to reduce code and sync mid-cap to end of cap data",
+          "refactoring the all of the event for base tracking, flag tracking, and score tracking to use a single event UPDATE_UI_WIDGET",
+          "added new support for mid-game loading where i make an initial call to get active bases by mapID instead of widgetID",
+          "fixed a bug related to the algorithm to ensure the correct minimum bases you need to hold",
+          "fixed missing variable assignments in the score trigger checks",
+          "clearing the interface upon joining any pvp game in order to hide it on maps that aren't yet supported or in arena",
+          "removed unused code and some remnants of the old ways of getting bases and handling bars",
+          "adding foundational code for silvershard mines, warsong gulch, and twin peaks",
+          "update to mod events in the new cleanup",
+          "making some remaining static strings config variables to be fully dynamic",
+        },
+      },
+    },
+  },
+  {
+    Version = "8.0.8",
+    General = "Adding tie game support",
+    Sections = {
+      {
+        Header = "General",
+        Entries = {
+          "adding support for TIE games",
+          "adding WoW Interface project ID",
+          "update the user experience for the anchor",
+        },
+      },
+    },
+  },
+  {
+    Version = "8.0.7",
+    General = "Creating new banner only option",
+    Sections = {
+      {
+        Header = "General",
+        Entries = {
+          "providing an option to be able to only show the win banner if desired",
+          "abstracting out all global functions and utils possible to local vars for performance",
+        },
+      },
+    },
+  },
+  {
+    Version = "8.0.6",
+    General = "Matching cap needs to owned needs",
+    Sections = {
+      {
+        Header = "General",
+        Entries = {
+          "making sure future need info during an assault matches what you need after the bases cap over and become owned",
+        },
+      },
+    },
+  },
+  {
+    Version = "8.0.5",
+    General = "Fixing EOTS",
+    Sections = {
+      {
+        Header = "Bugfixes",
+        Entries = {
+          "removing the check for if you're in a random eots game as it produced incorrect results, and realistically we dont need to exclude eots from incoming base code because there will never trigger an incoming base on eots as that mechanism doesn't exist there, and on rated eots we always want the normal code anyways so its a win win to just remove the extra logic",
+        },
+      },
+    },
+  },
+  {
+    Version = "8.0.4",
+    General = "Clearing info leaving a battleground",
+    Sections = {
+      {
+        Header = "General",
+        Entries = {
+          "resetting game info when leaving battleground",
+          "update the user experience for the anchor",
+        },
+      },
+    },
+  },
+  {
+    Version = "8.0.3",
+    Sections = {
+      {
+        Header = "General",
+        Entries = {
+          "update toc",
+        },
+      },
+    },
+  },
+  {
+    Version = "8.0.2",
+    Sections = {
+      {
+        Header = "Bugfixes",
+        Entries = {
+          "fixing orb buff timer team name color",
+        },
+      },
+    },
+  },
+  {
+    Version = "8.0.1",
+    Sections = {
+      {
+        Header = "General",
+        Entries = {
+          "addon uploaded to github + curseforge",
+        },
+      },
+    },
+  },
+}
+
+function Changelog:Setup()
+  LibStub("LibChangelog"):Register(AddonName, changelog, NS.db, "lastReadVersion", "onlyShowWhenNewVersion")
+  LibStub("LibChangelog"):ShowChangelog(AddonName)
+end

--- a/core/config.lua
+++ b/core/config.lua
@@ -1,4 +1,4 @@
-local _, NS = ...
+local AddonName, NS = ...
 
 local select = select
 local UnitClass = UnitClass
@@ -60,6 +60,7 @@ local CreateFrame = CreateFrame
 ---@field deepwindgorge MapTable
 ---@field eyeofthestorm EOTSTable
 ---@field silvershardmines MapTable
+---@field deephaulravine MapTable
 ---@field templeofkotmogu TOKTable
 ---@field thebattleforgilneas MapTable
 ---@field twinpeaks MapTable
@@ -70,8 +71,11 @@ local CreateFrame = CreateFrame
 ---@field maps MapsTable
 ---@field position PositionArray
 ---@field lastFlagCapBy string
+---@field debug boolean
 
 ---@class DBTable : table
+---@field lastReadVersion string
+---@field onlyShowWhenNewVersion boolean
 ---@field global GlobalTable
 
 ---@class BGWC
@@ -81,22 +85,27 @@ local CreateFrame = CreateFrame
 ---@field LOADING_SCREEN_DISABLED function
 ---@field PLAYER_LEAVING_WORLD function
 ---@field PLAYER_ENTERING_WORLD function
+---@field PVP_MATCH_COMPLETE function
+---@field PLAYER_JOINED_PVP_MATCH function
 ---@field UNIT_AURA function
 ---@field ARENA_OPPONENT_UPDATE function
 ---@field CHAT_MSG_ADDON function
 ---@field CHAT_MSG_BG_SYSTEM_ALLIANCE function
 ---@field CHAT_MSG_BG_SYSTEM_HORDE function
 ---@field CHAT_MSG_BG_SYSTEM_NEUTRAL function
+---@field Init function
+---@field Shutdown function
 ---@field SlashCommands function
 ---@field frame Frame
----@field db DBTable
+---@field db GlobalTable
+---@field isInitialized boolean
 
 ---@type BGWC
 ---@diagnostic disable-next-line: missing-fields
 local BGWC = {}
 NS.BGWC = BGWC
 
-local BGWCFrame = CreateFrame("Frame", "BGWCFrame")
+local BGWCFrame = CreateFrame("Frame", AddonName .. "Frame")
 BGWCFrame:SetScript("OnEvent", function(_, event, ...)
   if BGWC[event] then
     BGWC[event](BGWC, ...)
@@ -127,16 +136,17 @@ NS.IS_SSM = false
 NS.IS_TP = false
 NS.IS_WG = false
 NS.IS_BLITZ = false
-NS.DEBUG = false
 
 NS.userClass = select(2, UnitClass("player"))
 NS.userClassHexColor = "|c" .. select(4, GetClassColor(NS.userClass))
 
 NS.ADDON_PREFIX = "BGWC_VERSION"
 NS.FoundNewVersion = false
-NS.VERSION = 9622
+NS.VERSION = 970
 
 NS.DefaultDatabase = {
+  lastReadVersion = "9.6.22",
+  onlyShowWhenNewVersion = true,
   global = {
     general = {
       lock = false,
@@ -227,6 +237,9 @@ NS.DefaultDatabase = {
       silvershardmines = {
         enabled = false,
       },
+      deephaulravine = {
+        enabled = false,
+      },
       templeofkotmogu = {
         enabled = true,
         showorbinfo = true,
@@ -252,6 +265,7 @@ NS.DefaultDatabase = {
     },
     lastFlagCapBy = "",
     version = NS.VERSION,
+    debug = false,
   },
 }
 
@@ -283,4 +297,7 @@ NS.DefaultDatabase = {
 -- Seething Shore
 -- Instance ID: 1803
 -- Zone ID: 907
+-- Deephaul Ravine
+-- Instance ID: 2656
+-- Zone ID: 2345
 --]]

--- a/core/interface.lua
+++ b/core/interface.lua
@@ -63,6 +63,21 @@ function Interface:Clear()
   Flags:Stop(Flags)
 end
 
+function Interface:Start()
+  if NS.db and NS.db.global.general.test then
+    if NS.db.global.general.banner then
+      Interface:CreateTestBanner()
+    else
+      if NS.db.global.general.info then
+        Interface:CreateTestInfo()
+      else
+        Interface:CreateTestBanner()
+        Interface:CreateTestInfo()
+      end
+    end
+  end
+end
+
 function Interface:Refresh()
   Anchor:SetAnchor()
   Banner:SetTextColor(Banner.text, NS.db.global.general.bannergroup.tietextcolor)

--- a/core/maps.lua
+++ b/core/maps.lua
@@ -7,10 +7,7 @@ local GetInstanceInfo = GetInstanceInfo
 local GetNumGroupMembers = GetNumGroupMembers
 
 local After = C_Timer.After
-
----@type BGWC
-local BGWC = NS.BGWC
-local BGWCFrame = NS.BGWC.frame
+local IsSoloRBG = C_PvP.IsSoloRBG
 
 local Interface = NS.Interface
 local Version = NS.Version
@@ -26,71 +23,45 @@ do
     zoneIds[instanceID] = self
   end
 
-  -- The "PLAYER_LEAVING_WORLD" and "PLAYER_LOGOUT" events both fire on a ui reload so addons can shut down cleanly before being reloaded
-  -- https://www.reddit.com/r/wowaddons/comments/92ch0u/comment/e34zj4j/
-  function BGWC:PLAYER_LEAVING_WORLD()
-    BGWCFrame:UnregisterEvent("PLAYER_LEAVING_WORLD")
-
-    local inInstance = IsInInstance()
-    if not inInstance or inInstance == false then
-      NS.PLAYER_FACTION = GetPlayerFactionGroup()
+  function Maps:DisableZone()
+    if zoneIds[prevZone] then
       zoneIds[prevZone]:ExitZone()
       prevZone = 0
     end
   end
 
   function Maps:EnableZone(instanceID, isBlitz)
-    BGWCFrame:RegisterEvent("PLAYER_LEAVING_WORLD")
-
     NS.PLAYER_FACTION = GetPlayerFactionGroup()
     NS.IS_BLITZ = NS.isBlitz()
+
     prevZone = instanceID
+    zoneIds[instanceID]:EnterZone(instanceID, isBlitz)
 
     Version:SendVersion()
-
-    if NS.DEBUG then
-      print("Maps:EnableZone(instanceID, isBlitz)", NS.PLAYER_FACTION, isBlitz)
-    end
-
-    zoneIds[instanceID]:EnterZone(instanceID, isBlitz)
   end
 
   local function checkMaxPlayers(instanceID)
-    local maxPlayers = select(5, GetInstanceInfo())
-    local groupSize = GetNumGroupMembers()
+    local function checkPlayers()
+      local maxPlayers = select(5, GetInstanceInfo())
+      local groupSize = GetNumGroupMembers()
 
-    if NS.DEBUG then
-      print("checkMaxPlayers(instanceID)", maxPlayers, groupSize)
-    end
-
-    if maxPlayers == 0 then
-      After(1, function()
-        checkMaxPlayers(instanceID)
-      end)
-    else
-      if maxPlayers >= NS.DEFAULT_GROUP_SIZE or groupSize > NS.MIN_GROUP_SIZE then
-        Maps:EnableZone(instanceID, false)
+      if maxPlayers == 0 then
+        After(1, checkPlayers)
       else
-        Maps:EnableZone(instanceID, true)
+        local isBlitz = not (maxPlayers >= NS.DEFAULT_GROUP_SIZE or groupSize > NS.MIN_GROUP_SIZE or not IsSoloRBG())
+
+        Maps:EnableZone(instanceID, isBlitz)
       end
     end
+
+    checkPlayers()
   end
 
   function Maps:PrepareZone()
-    NS.PLAYER_FACTION = GetPlayerFactionGroup()
-
-    if NS.DEBUG then
-      print("Maps:PrepareZone()", NS.PLAYER_FACTION)
-    end
-
-    Interface:Clear()
-
-    local inInstance = IsInInstance()
-    if inInstance then
-      local instanceID = select(8, GetInstanceInfo())
-
+    if IsInInstance() then
       NS.IN_GAME = true
 
+      local instanceID = select(8, GetInstanceInfo())
       if zoneIds[instanceID] then
         checkMaxPlayers(instanceID)
       end
@@ -98,41 +69,8 @@ do
       NS.IN_GAME = false
       NS.IS_BLITZ = false
 
-      if NS.db.global.general.test then
-        if NS.db.global.general.banner then
-          Interface:CreateTestBanner()
-        else
-          if NS.db.global.general.info then
-            Interface:CreateTestInfo()
-          else
-            Interface:CreateTestBanner()
-            Interface:CreateTestInfo()
-          end
-        end
-      end
+      Interface:Start()
     end
-  end
-
-  -- Fired when loading screen disappears; when player is finished loading the new zone.
-  -- Also fired upon death, which we don't want, so we unregister it after its first use
-  -- Because of this we dont want to use this as a reliable source to start the zone code
-  function BGWC:LOADING_SCREEN_DISABLED()
-    BGWCFrame:UnregisterEvent("LOADING_SCREEN_DISABLED")
-    NS.PLAYER_FACTION = GetPlayerFactionGroup()
-
-    if NS.DEBUG then
-      print("BGWC:LOADING_SCREEN_DISABLED()", NS.PLAYER_FACTION)
-    end
-  end
-
-  function Maps:ToggleZone()
-    BGWCFrame:RegisterEvent("LOADING_SCREEN_DISABLED")
-
-    if NS.DEBUG then
-      print("Maps:ToggleZone()", NS.PLAYER_FACTION)
-    end
-
-    self:PrepareZone()
   end
 end
 

--- a/embeds.xml
+++ b/embeds.xml
@@ -5,4 +5,5 @@
   <Include file="libs\AceConfig-3.0\AceConfig-3.0.xml"/>
   <Include file="libs\LibSharedMedia-3.0\lib.xml"/>
   <Include file="libs\AceGUI-3.0-SharedMediaWidgets\widget.xml"/>
+  <Include file="libs\LibChangelog\LibChangelog.xml"/>
 </Ui>

--- a/interface/banner.lua
+++ b/interface/banner.lua
@@ -51,7 +51,10 @@ local function stopAnimation(frame, animationGroup)
   end
 
   frame.frame:SetAlpha(0)
-  frame.text:SetFormattedText("")
+
+  if frame.text then
+    frame.text:SetFormattedText("")
+  end
 end
 
 function Banner:Stop(frame, animationGroup)
@@ -76,7 +79,7 @@ local function animationUpdate(frame, text, animationGroup)
       animationGroup:Stop()
     end
 
-    -- frame.text:Hide()
+  -- frame.text:Hide()
   else
     local time = frame.exp - t
     frame.remaining = time

--- a/interface/banner.lua
+++ b/interface/banner.lua
@@ -7,7 +7,7 @@ local GetTime = GetTime
 local mmin = math.min
 local mmax = math.max
 
-local LSM = LibStub("LibSharedMedia-3.0")
+local SharedMedia = LibStub("LibSharedMedia-3.0")
 
 local Banner = {}
 NS.Banner = Banner
@@ -32,7 +32,7 @@ function Banner:SetTextColor(frame, color)
 end
 
 function Banner:SetFont(frame)
-  frame:SetFont(LSM:Fetch("font", NS.db.global.general.bannergroup.bannerfont), 12, "NORMAL")
+  frame:SetFont(SharedMedia:Fetch("font", NS.db.global.general.bannergroup.bannerfont), 12, "NORMAL")
 end
 
 function Banner:SetScale(frame)

--- a/interface/bases.lua
+++ b/interface/bases.lua
@@ -13,7 +13,7 @@ local sformat = string.format
 local Info = NS.Info
 local Banner = NS.Banner
 
-local LSM = LibStub("LibSharedMedia-3.0")
+local SharedMedia = LibStub("LibSharedMedia-3.0")
 
 local Bases = {}
 NS.Bases = Bases
@@ -36,7 +36,7 @@ end
 
 function Bases:SetFont(frame)
   frame:SetFont(
-    LSM:Fetch("font", NS.db.global.general.infogroup.infofont),
+    SharedMedia:Fetch("font", NS.db.global.general.infogroup.infofont),
     NS.db.global.general.infogroup.infofontsize,
     "OUTLINE"
   )

--- a/interface/bases.lua
+++ b/interface/bases.lua
@@ -55,7 +55,10 @@ local function stopAnimation(frame, animationGroup)
   end
 
   frame.frame:SetAlpha(0)
-  frame.text:SetFormattedText("")
+
+  if frame.text then
+    frame.text:SetFormattedText("")
+  end
 end
 
 function Bases:Stop(frame, animationGroup)
@@ -232,9 +235,7 @@ local function animationUpdate(frame, winTable, animationGroup, callbackFn)
                           loseMessage(frame.text, winCondition)
                         end
                       else
-                        if NS.DEBUG then
-                          print("NO OPTIONS LEFT")
-                        end
+                        NS.Debug("NO OPTIONS LEFT")
                       end
                     end
                   end

--- a/interface/flags.lua
+++ b/interface/flags.lua
@@ -53,7 +53,10 @@ end
 
 function Flags:Stop(frame)
   frame.frame:SetAlpha(0)
-  frame.text:SetFormattedText("")
+
+  if frame.text then
+    frame.text:SetFormattedText("")
+  end
 end
 
 function Flags:Create(anchor)

--- a/interface/flags.lua
+++ b/interface/flags.lua
@@ -3,7 +3,7 @@ local AddonName, NS = ...
 local CreateFrame = CreateFrame
 local LibStub = LibStub
 
-local LSM = LibStub("LibSharedMedia-3.0")
+local SharedMedia = LibStub("LibSharedMedia-3.0")
 
 local Info = NS.Info
 
@@ -38,7 +38,7 @@ end
 
 function Flags:SetFont(frame)
   frame:SetFont(
-    LSM:Fetch("font", NS.db.global.general.infogroup.infofont),
+    SharedMedia:Fetch("font", NS.db.global.general.infogroup.infofont),
     NS.db.global.general.infogroup.infofontsize,
     "OUTLINE"
   )

--- a/interface/orbs.lua
+++ b/interface/orbs.lua
@@ -7,7 +7,7 @@ local ipairs = ipairs
 
 local sformat = string.format
 
-local LSM = LibStub("LibSharedMedia-3.0")
+local SharedMedia = LibStub("LibSharedMedia-3.0")
 
 local Info = NS.Info
 local Banner = NS.Banner
@@ -43,7 +43,7 @@ end
 
 function Orbs:SetFont(frame)
   frame:SetFont(
-    LSM:Fetch("font", NS.db.global.general.infogroup.infofont),
+    SharedMedia:Fetch("font", NS.db.global.general.infogroup.infofont),
     NS.db.global.general.infogroup.infofontsize,
     "OUTLINE"
   )

--- a/interface/orbs.lua
+++ b/interface/orbs.lua
@@ -127,8 +127,13 @@ local function stopAnimation(frame, animationGroup)
     animationGroup:Stop()
   end
 
-  frame.buffText:SetFormattedText("")
-  frame.buffTextFrame:SetAlpha(0)
+  if frame.buffTextFrame then
+    frame.buffTextFrame:SetAlpha(0)
+  end
+
+  if frame.buffText then
+    frame.buffText:SetFormattedText("")
+  end
 end
 
 function Orbs:Stop(frame, animationGroup, everything)
@@ -136,7 +141,10 @@ function Orbs:Stop(frame, animationGroup, everything)
 
   if everything then
     frame.frame:SetAlpha(0)
-    frame.orbText:SetFormattedText("")
+
+    if frame.orbText then
+      frame.orbText:SetFormattedText("")
+    end
 
     if NS.IN_GAME then
       Info.frame:SetSize(1, 1)
@@ -155,7 +163,7 @@ local function animationUpdate(frame, text, animationGroup)
     end
 
     Orbs:SetText(frame.buffText, orbsformat2, text)
-    -- frame.buffText:Hide()
+  -- frame.buffText:Hide()
   else
     local time = frame.exp - t
     frame.remaining = time

--- a/interface/score.lua
+++ b/interface/score.lua
@@ -55,7 +55,10 @@ end
 
 function Score:Stop(frame)
   frame.frame:SetAlpha(0)
-  frame.text:SetFormattedText("")
+
+  if frame.text then
+    frame.text:SetFormattedText("")
+  end
 end
 
 function Score:Create(anchor)

--- a/interface/score.lua
+++ b/interface/score.lua
@@ -3,7 +3,7 @@ local AddonName, NS = ...
 local CreateFrame = CreateFrame
 local LibStub = LibStub
 
-local LSM = LibStub("LibSharedMedia-3.0")
+local SharedMedia = LibStub("LibSharedMedia-3.0")
 
 local Info = NS.Info
 
@@ -40,7 +40,7 @@ end
 
 function Score:SetFont(frame)
   frame:SetFont(
-    LSM:Fetch("font", NS.db.global.general.infogroup.infofont),
+    SharedMedia:Fetch("font", NS.db.global.general.infogroup.infofont),
     NS.db.global.general.infogroup.infofontsize,
     "OUTLINE"
   )

--- a/interface/stacks.lua
+++ b/interface/stacks.lua
@@ -5,7 +5,7 @@ local LibStub = LibStub
 local GetTime = GetTime
 local UnitIsDeadOrGhost = UnitIsDeadOrGhost
 
-local LSM = LibStub("LibSharedMedia-3.0")
+local SharedMedia = LibStub("LibSharedMedia-3.0")
 
 local Info = NS.Info
 local Banner = NS.Banner
@@ -39,7 +39,7 @@ end
 
 function Stacks:SetFont(frame)
   frame:SetFont(
-    LSM:Fetch("font", NS.db.global.general.infogroup.infofont),
+    SharedMedia:Fetch("font", NS.db.global.general.infogroup.infofont),
     NS.db.global.general.infogroup.infofontsize,
     "OUTLINE"
   )

--- a/interface/stacks.lua
+++ b/interface/stacks.lua
@@ -58,7 +58,10 @@ local function stopAnimation(frame, animationGroup)
   end
 
   frame.frame:SetAlpha(0)
-  frame.text:SetFormattedText("")
+
+  if frame.text then
+    frame.text:SetFormattedText("")
+  end
 
   if NS.IN_GAME then
     Info.frame:SetSize(1, 1)

--- a/libs/LibChangelog/CHANGELOG.md
+++ b/libs/LibChangelog/CHANGELOG.md
@@ -1,0 +1,8 @@
+# LibChangelog
+
+## [1.0.2](https://github.com/BullseiWoWAddons/LibChangelog/tree/1.0.2) (2023-04-04)
+[Full Changelog](https://github.com/BullseiWoWAddons/LibChangelog/compare/1.0.1...1.0.2) [Previous Releases](https://github.com/BullseiWoWAddons/LibChangelog/releases)
+
+- bump version  
+- Update setttings and fix error in wotlk  
+- Update README.md  

--- a/libs/LibChangelog/LibChangelog.lua
+++ b/libs/LibChangelog/LibChangelog.lua
@@ -1,0 +1,187 @@
+--- LibChangelog
+-- Provides an way to create a simple ingame frame to show a changelog
+
+
+
+local _, Data = ...
+local L = Data.L
+
+
+local MAJOR, MINOR = "LibChangelog", 1
+local LibChangelog = LibStub:NewLibrary(MAJOR, MINOR)
+
+if not LibChangelog then return end
+
+
+-- Lua APIs
+local pcall, error, type, pairs = pcall, error, type, pairs
+
+
+
+
+local NEW_MESSAGE_FONTS = {
+    version = GameFontNormalHuge,
+    title = GameFontNormal,
+    text = GameFontHighlight
+}
+
+local VIEWED_MESSAGE_FONTS = {
+    version = GameFontDisableHuge,
+    title = GameFontDisable,
+    text = GameFontDisable
+}
+
+function LibChangelog:Register(addonName, changelogTable, savedVariablesTable, lastReadVersionKey, onlyShowWhenNewVersionKey, texts)
+
+    if self[addonName] then return error("LibChangelog: '"..addonName.."' already registered", 2) end
+
+
+    self[addonName] = {
+        changelogTable = changelogTable,
+        savedVariablesTable = savedVariablesTable,
+        lastReadVersionKey = lastReadVersionKey,
+        onlyShowWhenNewVersionKey = onlyShowWhenNewVersionKey,
+        texts = texts or {}
+    }
+end
+
+function LibChangelog:CreateString(frame, text, font, offset)
+    local entry = frame.scrollChild:CreateFontString(nil, "ARTWORK")
+  
+    if offset == nil then
+      offset = -5
+    end
+  
+
+    --print("ScrollChild width", frame.scrollChild:GetWidth())
+    --print("scrollBar width", frame.scrollBar:GetWidth())
+    -- frame.scrollBar:GetWidth() == frame.scrollChild:GetWidth()
+
+    entry:SetFontObject(font or "GameFontNormal")
+    entry:SetText(text)
+    entry:SetJustifyH("LEFT")
+    entry:SetWidth(frame.scrollBar:GetWidth())
+  
+    if frame.previous then
+      entry:SetPoint("TOPLEFT", frame.previous, "BOTTOMLEFT", 0, offset)
+    else
+      entry:SetPoint("TOPLEFT", frame.scrollChild, "TOPLEFT", -5)
+    end
+  
+    frame.previous = entry
+
+    return entry
+end
+
+-- Did this just to get nice alignment on the bulleted entries (otherwise the text wrapped below the bulle
+
+function LibChangelog:CreateBulletedListEntry(frame, text, font, offset)
+    local bullet = self:CreateString(frame, "- ", font, offset)
+
+    local bulletWidth = 16
+
+    bullet:SetWidth(bulletWidth)
+    bullet:SetJustifyV("TOP")
+  
+    local entry = self:CreateString(frame, text, font, offset)
+    entry:SetPoint("TOPLEFT", bullet, "TOPRIGHT")
+    entry:SetWidth(frame.scrollBar:GetWidth() - bulletWidth)
+  
+    bullet:SetHeight(entry:GetStringHeight())
+  
+    frame.previous = bullet
+    return bullet
+end
+
+function LibChangelog:ShowChangelog(addonName)
+    local fonts = NEW_MESSAGE_FONTS
+  
+    local addonData = self[addonName]
+
+    if not addonData then return error("LibChangelog: '"..addonName.. "' was not registered. Please use :Register() first", 2) end
+
+    local firstEntry = addonData.changelogTable[1]  --firstEntry contains the newest Version
+
+    local addonSavedVariablesTable = addonData.savedVariablesTable
+
+    if addonData.lastReadVersionKey and addonSavedVariablesTable[addonData.lastReadVersionKey] and firstEntry.Version <= addonSavedVariablesTable[addonData.lastReadVersionKey] and  addonSavedVariablesTable[addonData.onlyShowWhenNewVersionKey] then return end
+
+  
+    if not addonData.frame then
+
+        local frame = CreateFrame("Frame", nil, UIParent, "ButtonFrameTemplate")
+        ButtonFrameTemplate_HidePortrait(frame)
+        if frame.SetTitle then
+            frame:SetTitle(addonData.texts.title or addonName.." News")
+        else
+            --workaround for TBCC
+            frame.TitleText:SetText(addonData.texts.title or addonName.." News")
+        end
+        frame.Inset:SetPoint("TOPLEFT", 4, -25)
+        
+        -- frame:EnableMouse(true)
+        
+        frame:SetSize(500, 500)
+        frame:SetPoint("CENTER")
+        -- frame:SetMovable(true)
+        -- frame:RegisterForDrag("LeftButton")
+        -- frame:SetScript("OnDragStart", frame.StartMoving)
+        -- frame:SetScript("OnDragStop", frame.StopMovingOrSizing)
+        
+        frame.scrollBar = CreateFrame("ScrollFrame", nil, frame.Inset, "UIPanelScrollFrameTemplate")
+        frame.scrollBar:SetPoint("TOPLEFT", 10, -6)
+        frame.scrollBar:SetPoint("BOTTOMRIGHT", -27, 6)
+        
+        frame.scrollChild = CreateFrame("Frame")
+        frame.scrollChild:SetSize(1, 1) -- it doesnt seem to matter how big it is, the only thing that not works is setting the height to really high number, then you can scroll forever
+        
+        frame.scrollBar:SetScrollChild(frame.scrollChild)
+
+        frame.CheckButton = CreateFrame("CheckButton", nil, frame, "UICheckButtonTemplate")
+        frame.CheckButton:SetChecked(addonSavedVariablesTable[addonData.onlyShowWhenNewVersionKey])
+        frame.CheckButton:SetFrameStrata("HIGH")
+        frame.CheckButton:SetSize(20, 20)
+        frame.CheckButton:SetScript("OnClick", function(self)
+            local isChecked = self:GetChecked()
+            addonSavedVariablesTable[addonData.onlyShowWhenNewVersionKey] = isChecked
+            frame.CheckButton:SetChecked(isChecked)
+        end)
+        frame.CheckButton:SetPoint("LEFT", frame, "BOTTOMLEFT", 10, 13)
+        if frame.CheckButton.text then
+            frame.CheckButton.text:SetText(addonData.texts.onlyShowWhenNewVersion or "Only Show after next update")
+        elseif frame.CheckButton.Text
+            then  frame.CheckButton.Text:SetText(addonData.texts.onlyShowWhenNewVersion or "Only Show after next update")
+        end
+
+        addonData.frame = frame
+    end
+
+
+    for i = 1, #addonData.changelogTable do
+        local versionEntry = addonData.changelogTable[i]
+
+        if addonData.lastReadVersionKey and addonSavedVariablesTable[addonData.lastReadVersionKey] and addonSavedVariablesTable[addonData.lastReadVersionKey] >= versionEntry.Version then
+            fonts = VIEWED_MESSAGE_FONTS
+        end
+
+        -- Add version string
+        self:CreateString(addonData.frame, versionEntry.Version, fonts.version, -30) --add a nice spacing between the version header and the previous text
+
+        if versionEntry.General then
+            self:CreateString(addonData.frame, versionEntry.General, fonts.text)
+        end
+
+        if versionEntry.Sections then
+            for i = 1, #versionEntry.Sections do
+                local section = versionEntry.Sections[i]
+                self:CreateString(addonData.frame, section.Header, fonts.title, -8)
+                local entries = section.Entries
+                for j = 1, #entries do
+                    self:CreateBulletedListEntry(addonData.frame, entries[j], fonts.text)
+                end
+            end
+        end
+    end
+
+    addonSavedVariablesTable[addonData.lastReadVersionKey] = firstEntry.Version
+end

--- a/libs/LibChangelog/LibChangelog.toc
+++ b/libs/LibChangelog/LibChangelog.toc
@@ -1,0 +1,8 @@
+## Interface: 90005
+## Title: LibChangelog
+## Version: 1.0.2
+## Author: Bullsei
+
+## X-Curse-Project-ID: 497698
+
+LibChangelog.xml

--- a/libs/LibChangelog/LibChangelog.xml
+++ b/libs/LibChangelog/LibChangelog.xml
@@ -1,0 +1,4 @@
+<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
+..\FrameXML\UI.xsd">
+	<Script file="LibChangelog.lua"/>
+</Ui>

--- a/libs/LibChangelog/README.md
+++ b/libs/LibChangelog/README.md
@@ -1,0 +1,3 @@
+# LibChangelog
+
+https://github.com/BullseiWoWAddons/LibChangelog/wiki/How-to-use

--- a/maps/ArathiBasin.lua
+++ b/maps/ArathiBasin.lua
@@ -13,73 +13,81 @@ local AB = Maps:NewMod()
 -- NS.CONTROL_TIME = 45
 -- NS.RESET_TIME = 5
 
+local commonConfig = {
+  maxBases = 5,
+  tickRate = 2,
+  assaultTime = 6,
+  contestedTime = 60,
+  resetTime = 0,
+  controlTime = 0,
+  baseResources = {
+    [0] = 0,
+    [1] = 1, -- blitz = 3.5 = 7
+    [2] = 1.5, -- blitz = 5 = 10
+    [3] = 2, -- blitz = 7.5 = 15
+    [4] = 3.5, -- blitz = 25 = 50
+    [5] = 30, -- blitz = 32.5 = 65
+  },
+}
+
 local instanceIdToMapId = {
   -- ArathiBasin
   [2107] = {
     id = 1366,
-    maxBases = 5,
-    tickRate = 2,
-    assaultTime = 6,
-    contestedTime = 60,
-    resetTime = 0,
-    baseResources = {
-      [0] = 0,
-      [1] = 1,
-      [2] = 1.5,
-      [3] = 2,
-      [4] = 3.5,
-      [5] = 30,
-    },
+    maxBases = commonConfig.maxBases,
+    tickRate = commonConfig.tickRate,
+    assaultTime = commonConfig.assaultTime,
+    contestedTime = commonConfig.contestedTime,
+    resetTime = commonConfig.resetTime,
+    controlTime = commonConfig.controlTime,
+    baseResources = commonConfig.baseResources,
   },
   -- ArathiCompStomp
   [2177] = {
     id = 1383,
-    maxBases = 5,
-    tickRate = 2,
-    assaultTime = 6,
-    contestedTime = 60,
-    resetTime = 0,
-    baseResources = {
-      [0] = 0,
-      [1] = 1,
-      [2] = 1.5,
-      [3] = 2,
-      [4] = 3.5,
-      [5] = 30,
-    },
+    maxBases = commonConfig.maxBases,
+    tickRate = commonConfig.tickRate,
+    assaultTime = commonConfig.assaultTime,
+    contestedTime = commonConfig.contestedTime,
+    resetTime = commonConfig.resetTime,
+    controlTime = commonConfig.controlTime,
+    baseResources = commonConfig.baseResources,
   },
   -- ArathiBlizzard
   [1681] = {
     id = 837,
-    maxBases = 5,
-    tickRate = 2,
-    assaultTime = 6,
-    contestedTime = 60,
-    resetTime = 0,
-    baseResources = {
-      [0] = 0,
-      [1] = 1,
-      [2] = 1.5,
-      [3] = 2,
-      [4] = 3.5,
-      [5] = 30,
-    },
+    maxBases = commonConfig.maxBases,
+    tickRate = commonConfig.tickRate,
+    assaultTime = commonConfig.assaultTime,
+    contestedTime = commonConfig.contestedTime,
+    resetTime = commonConfig.resetTime,
+    controlTime = commonConfig.controlTime,
+    baseResources = commonConfig.baseResources,
   },
 }
 
 local function checkInfo(id, isBlitz)
   local convertedInfo = {}
   convertedInfo = NS.CopyTable(instanceIdToMapId[id], convertedInfo)
-  convertedInfo.assaultTime = isBlitz and 4 or 6
-  convertedInfo.contestedTime = isBlitz and 30 or 60
+  convertedInfo.assaultTime = isBlitz and 4 or commonConfig.assaultTime
+  convertedInfo.contestedTime = isBlitz and 30 or commonConfig.contestedTime
+  convertedInfo.resetTime = isBlitz and 5 or commonConfig.resetTime
+  convertedInfo.controlTime = isBlitz and 45 or commonConfig.controlTime
+  convertedInfo.baseResources = {
+    [0] = commonConfig.baseResources[0],
+    [1] = isBlitz and 3.5 or commonConfig.baseResources[1],
+    [2] = isBlitz and 5 or commonConfig.baseResources[2],
+    [3] = isBlitz and 7.5 or commonConfig.baseResources[3],
+    [4] = isBlitz and 25 or commonConfig.baseResources[4],
+    [5] = isBlitz and 32.5 or commonConfig.baseResources[5],
+  }
   return convertedInfo
 end
 
 function AB:EnterZone(id, isBlitz)
-  if NS.db.global.maps.arathibasin.enabled then
+  if NS.db and NS.db.global.maps.arathibasin.enabled then
     if not isBlitz or isBlitz == false then
       Info:SetAnchor(Banner.frame, 0, 0)
-
       BasePrediction:StartInfoTracker(checkInfo(id, isBlitz))
     end
   end

--- a/maps/DeephaulRavine.lua
+++ b/maps/DeephaulRavine.lua
@@ -1,0 +1,60 @@
+local _, NS = ...
+
+local next = next
+
+-- local CartPrediction = NS.CartPrediction
+local Banner = NS.Banner
+local Info = NS.Info
+local Maps = NS.Maps
+
+local DHR = Maps:NewMod()
+
+local instanceIdToMapId = {
+  -- Deephaul Ravine
+  [2656] = {
+    id = 2345,
+    maxCarts = 2,
+    tickRate = 2,
+    flagResources = {
+      [0] = 0,
+      [1] = 100,
+      [2] = 100,
+    },
+    cartResources = {
+      [0] = 0,
+      [1] = 1.5,
+      [2] = 3,
+    },
+    -- Cart capping times in seconds, rounded up 1 second each
+    cartTimers = {
+      [0] = 10, -- 9sec -- respawn
+      [1] = 181, -- 3min 0sec -- top short
+      [2] = 233, -- 3min 52sec -- top long
+    },
+  },
+}
+
+-- local function checkInfo(id, isBlitz)
+--   local convertedInfo = {}
+--   convertedInfo = NS.CopyTable(instanceIdToMapId[id], convertedInfo)
+--   return convertedInfo
+-- end
+
+function DHR:EnterZone(id, isBlitz)
+  if NS.db and NS.db.global.maps.deephaulravine.enabled then
+    if not isBlitz or isBlitz == false then
+      Info:SetAnchor(Banner.frame, 0, 0)
+      -- CartPrediction:StartInfoTracker(checkInfo(id, isBlitz))
+    end
+  end
+end
+
+function DHR:ExitZone()
+  -- if NS.db.global.maps.deephaulravine.enabled then
+  --   -- CartPrediction:StopInfoTracker()
+  -- end
+end
+
+for id in next, instanceIdToMapId do
+  DHR:RegisterZone(id)
+end

--- a/maps/DeepwindGorge.lua
+++ b/maps/DeepwindGorge.lua
@@ -9,39 +9,59 @@ local Maps = NS.Maps
 
 local DWG = Maps:NewMod()
 
+local commonConfig = {
+  maxBases = 5,
+  tickRate = 2,
+  assaultTime = 6,
+  contestedTime = 60,
+  resetTime = 0,
+  controlTime = 0,
+  baseResources = {
+    [0] = 0,
+    [1] = 1, -- blitz = 3.5 = 7
+    [2] = 1.5, -- blitz = 5 = 10
+    [3] = 2, -- blitz = 7.5 = 15
+    [4] = 3.5, -- blitz = 25 = 50
+    [5] = 30, -- blitz = 32.5 = 65
+  },
+}
+
 local instanceIdToMapId = {
   -- DeepwindGorge
   [2245] = {
     id = 1576,
-    maxBases = 5,
-    tickRate = 2,
-    assaultTime = 6,
-    contestedTime = 60,
-    resetTime = 0,
-    baseResources = {
-      [0] = 0,
-      [1] = 1,
-      [2] = 1.5,
-      [3] = 2,
-      [4] = 3.5,
-      [5] = 30,
-    },
+    maxBases = commonConfig.maxBases,
+    tickRate = commonConfig.tickRate,
+    assaultTime = commonConfig.assaultTime,
+    contestedTime = commonConfig.contestedTime,
+    resetTime = commonConfig.resetTime,
+    controlTime = commonConfig.controlTime,
+    baseResources = commonConfig.baseResources,
   },
 }
 
 local function checkInfo(id, isBlitz)
   local convertedInfo = {}
   convertedInfo = NS.CopyTable(instanceIdToMapId[id], convertedInfo)
-  convertedInfo.assaultTime = isBlitz and 4 or 6
-  convertedInfo.contestedTime = isBlitz and 30 or 60
+  convertedInfo.assaultTime = isBlitz and 4 or commonConfig.assaultTime
+  convertedInfo.contestedTime = isBlitz and 30 or commonConfig.contestedTime
+  convertedInfo.resetTime = isBlitz and 5 or commonConfig.resetTime
+  convertedInfo.controlTime = isBlitz and 45 or commonConfig.controlTime
+  convertedInfo.baseResources = {
+    [0] = commonConfig.baseResources[0],
+    [1] = isBlitz and 3.5 or commonConfig.baseResources[1],
+    [2] = isBlitz and 5 or commonConfig.baseResources[2],
+    [3] = isBlitz and 7.5 or commonConfig.baseResources[3],
+    [4] = isBlitz and 25 or commonConfig.baseResources[4],
+    [5] = isBlitz and 32.5 or commonConfig.baseResources[5],
+  }
   return convertedInfo
 end
 
 function DWG:EnterZone(id, isBlitz)
-  if NS.db.global.maps.deepwindgorge.enabled then
+  if NS.db and NS.db.global.maps.deepwindgorge.enabled then
     if not isBlitz or isBlitz == false then
       Info:SetAnchor(Banner.frame, 0, 0)
-
       BasePrediction:StartInfoTracker(checkInfo(id, isBlitz))
     end
   end

--- a/maps/EyeoftheStorm.lua
+++ b/maps/EyeoftheStorm.lua
@@ -11,63 +11,61 @@ local Bases = NS.Bases
 
 local EOTS = Maps:NewMod()
 
+local commonConfig = {
+  maxBases = 4,
+  tickRate = 2,
+  assaultTime = 6,
+  contestedTime = 60,
+  resetTime = 15,
+  baseResources = {
+    [0] = 0,
+    [1] = 1,
+    [2] = 1.5,
+    [3] = 2,
+    [4] = 6,
+  },
+  flagResources = {
+    [0] = 0,
+    [1] = 75,
+    [2] = 85,
+    [3] = 100,
+    [4] = 500,
+  },
+}
+
+-- only iconState 1 has flag info
+-- "TEAM has taken the flag"
 local instanceIdToMapId = {
   -- EyeoftheStorm
-  -- only iconState 1 has flag info
-  -- "TEAM has taken the flag"
   [566] = {
     id = 112,
-    maxBases = 4,
-    tickRate = 2,
-    assaultTime = 6,
-    contestedTime = 60,
-    resetTime = 15,
-    baseResources = {
-      [0] = 0,
-      [1] = 1,
-      [2] = 1.5,
-      [3] = 2,
-      [4] = 6,
-    },
-    flagResources = {
-      [0] = 0,
-      [1] = 75,
-      [2] = 85,
-      [3] = 100,
-      [4] = 500,
-    },
+    maxBases = commonConfig.maxBases,
+    tickRate = commonConfig.tickRate,
+    assaultTime = commonConfig.assaultTime,
+    contestedTime = commonConfig.contestedTime,
+    resetTime = commonConfig.resetTime,
+    baseResources = commonConfig.baseResources,
+    flagResources = commonConfig.flagResources,
   },
   -- RatedEyeoftheStorm
   [968] = {
     id = 397,
-    maxBases = 4,
-    tickRate = 2,
-    assaultTime = 6,
-    contestedTime = 60,
-    resetTime = 15,
-    baseResources = {
-      [0] = 0,
-      [1] = 1,
-      [2] = 1.5,
-      [3] = 2,
-      [4] = 6,
-    },
-    flagResources = {
-      [0] = 0,
-      [1] = 75,
-      [2] = 85,
-      [3] = 100,
-      [4] = 500,
-    },
+    maxBases = commonConfig.maxBases,
+    tickRate = commonConfig.tickRate,
+    assaultTime = commonConfig.assaultTime,
+    contestedTime = commonConfig.contestedTime,
+    resetTime = commonConfig.resetTime,
+    baseResources = commonConfig.baseResources,
+    flagResources = commonConfig.flagResources,
   },
 }
 
 local function checkInfo(id, isBlitz)
   local convertedInfo = {}
   convertedInfo = NS.CopyTable(instanceIdToMapId[id], convertedInfo)
-  convertedInfo.assaultTime = isBlitz and 4 or 6
-  convertedInfo.contestedTime = isBlitz and 30 or 60
-  convertedInfo.maxBases = isBlitz and 2 or 4
+  convertedInfo.assaultTime = isBlitz and 4 or commonConfig.assaultTime
+  convertedInfo.contestedTime = isBlitz and 30 or commonConfig.contestedTime
+  convertedInfo.maxBases = isBlitz and 2 or commonConfig.maxBases
   convertedInfo.baseResources = isBlitz and {
     [0] = 0,
     [1] = 3.5,
@@ -84,10 +82,8 @@ end
 function EOTS:EnterZone(id, isBlitz)
   if NS.db.global.maps.eyeofthestorm.enabled then
     NS.IS_EOTS = true
-
     Info:SetAnchor(Banner.frame, 0, 0)
     Flags:SetAnchor(Bases.frame, 0, -5)
-
     BasePrediction:StartInfoTracker(checkInfo(id, isBlitz))
   end
 end

--- a/maps/SilvershardMines.lua
+++ b/maps/SilvershardMines.lua
@@ -42,12 +42,11 @@ local function checkInfo(id, isBlitz)
 end
 
 function SSM:EnterZone(id, isBlitz)
-  if NS.db.global.maps.silvershardmines.enabled then
+  if NS.db and NS.db.global.maps.silvershardmines.enabled then
     NS.IS_SSM = true
 
     if not isBlitz or isBlitz == false then
       Info:SetAnchor(Banner.frame, 0, 0)
-
       CartPrediction:StartInfoTracker(checkInfo(id, isBlitz))
     end
   end

--- a/maps/TempleofKotmogu.lua
+++ b/maps/TempleofKotmogu.lua
@@ -53,7 +53,7 @@ local function checkInfo(id, isBlitz)
 end
 
 function TOK:EnterZone(id, isBlitz)
-  if NS.db.global.maps.templeofkotmogu.enabled then
+  if NS.db and NS.db.global.maps.templeofkotmogu.enabled then
     NS.IS_TEMPLE = true
 
     Info:SetAnchor(Anchor.frame, 0, 0)

--- a/maps/TheBattleforGilneas.lua
+++ b/maps/TheBattleforGilneas.lua
@@ -9,42 +9,50 @@ local Maps = NS.Maps
 
 local TBFG = Maps:NewMod()
 
+local commonConfig = {
+  maxBases = 3,
+  tickRate = 1,
+  assaultTime = 6,
+  contestedTime = 60,
+  resetTime = 0,
+  baseResources = {
+    [0] = 0,
+    [1] = 1,
+    [2] = 3,
+    [3] = 30,
+  },
+}
+
 local instanceIdToMapId = {
   -- Gilneas
   [761] = {
     id = 275,
-    maxBases = 3,
-    tickRate = 1,
-    assaultTime = 6,
-    contestedTime = 60,
-    resetTime = 0,
-    baseResources = {
-      [0] = 0,
-      [1] = 1,
-      [2] = 3,
-      [3] = 30,
-    },
+    maxBases = commonConfig.maxBases,
+    tickRate = commonConfig.tickRate,
+    assaultTime = commonConfig.assaultTime,
+    contestedTime = commonConfig.contestedTime,
+    resetTime = commonConfig.resetTime,
+    baseResources = commonConfig.baseResources,
   },
 }
 
 local function checkInfo(id, isBlitz)
   local convertedInfo = {}
   convertedInfo = NS.CopyTable(instanceIdToMapId[id], convertedInfo)
-  convertedInfo.assaultTime = isBlitz and 4 or 6
-  convertedInfo.contestedTime = isBlitz and 30 or 60
+  convertedInfo.assaultTime = isBlitz and 4 or commonConfig.assaultTime
+  convertedInfo.contestedTime = isBlitz and 30 or commonConfig.contestedTime
   convertedInfo.baseResources = {
-    [0] = 0,
-    [1] = isBlitz and 2 or 1,
-    [2] = isBlitz and 5 or 3,
-    [3] = 30,
+    [0] = commonConfig.baseResources[0],
+    [1] = isBlitz and 2 or commonConfig.baseResources[1],
+    [2] = isBlitz and 5 or commonConfig.baseResources[2],
+    [3] = commonConfig.baseResources[3],
   }
   return convertedInfo
 end
 
 function TBFG:EnterZone(id, isBlitz)
-  if NS.db.global.maps.thebattleforgilneas.enabled then
+  if NS.db and NS.db.global.maps.thebattleforgilneas.enabled then
     Info:SetAnchor(Banner.frame, 0, 0)
-
     BasePrediction:StartInfoTracker(checkInfo(id, isBlitz))
   end
 end

--- a/maps/TwinPeaks.lua
+++ b/maps/TwinPeaks.lua
@@ -26,7 +26,7 @@ local function checkInfo(id, isBlitz)
 end
 
 function TP:EnterZone(id, isBlitz)
-  if NS.db.global.maps.twinpeaks.enabled then
+  if NS.db and NS.db.global.maps.twinpeaks.enabled then
     NS.IS_TP = true
 
     Info:SetAnchor(Banner.frame, 0, 0)

--- a/maps/WarsongGulch.lua
+++ b/maps/WarsongGulch.lua
@@ -26,7 +26,7 @@ local function checkInfo(id, isBlitz)
 end
 
 function WG:EnterZone(id, isBlitz)
-  if NS.db.global.maps.warsonggulch.enabled then
+  if NS.db and NS.db.global.maps.warsonggulch.enabled then
     NS.IS_WG = true
 
     Info:SetAnchor(Banner.frame, 0, 0)

--- a/predictions/bases.lua
+++ b/predictions/bases.lua
@@ -2,6 +2,7 @@ local _, NS = ...
 
 local next = next
 local pairs = pairs
+local ipairs = ipairs
 local GetTime = GetTime
 local CreateFrame = CreateFrame
 
@@ -10,6 +11,7 @@ local smatch = string.match
 local mfloor = math.floor
 local mceil = math.ceil
 local mmin = math.min
+local twipe = table.wipe
 
 local After = C_Timer.After
 local GetDoubleStatusBarWidgetVisualizationInfo = C_UIWidgetManager.GetDoubleStatusBarWidgetVisualizationInfo
@@ -81,7 +83,7 @@ do
       end
 
       for _, v in pairs(flagInfo.leftIcons) do
-        if v.iconState == 1 then
+        if v.iconState == Enum.IconState.ShowState1 then
           local str = v.state1Tooltip
 
           if sfind(str, "flag") then
@@ -91,7 +93,7 @@ do
       end
 
       for _, v in pairs(flagInfo.rightIcons) do
-        if v.iconState == 1 then
+        if v.iconState == Enum.IconState.ShowState1 then
           local str = v.state1Tooltip
 
           if sfind(str, "flag") then
@@ -105,11 +107,11 @@ do
   do
     local prevTime, prevAScore, prevHScore, prevAIncrease, prevHIncrease = 0, 0, 0, 0, 0
     local timeBetweenEachTick, prevTick, winTime = 0, 0, 0
-    local minScore, maxScore, aScore, hScore, aIncrease, hIncrease = 0, 0, 0, 0, 0, 0
+    local minScore, maxScore, aScore, hScore, aIncrease, hIncrease = 0, 1500, 0, 0, 0, 0
     local prevABases, prevHBases, prevAIncBases, prevHIncBases = 0, 0, 0, 0
 
     function BasePrediction:BasePredictor(refresh)
-      if aScore < 1500 and hScore < 1500 then
+      if aScore < maxScore and hScore < maxScore then
         if refresh then
           self:GetScoreByMapID(curMap.id)
           self:GetObjectivesByMapID(curMap.id)
@@ -156,7 +158,7 @@ do
             Banner:Start(winTime, winText)
             Score:SetText(Score.text, finalAScore, finalHScore)
 
-            -- local currentWinbases = aWins and allyBases or hordeBases
+            -- local currentWinBases = aWins and allyBases or hordeBases
             -- local currentLoseBases = aWins and hordeBases or allyBases
 
             local winBases = aWins and allyBases or hordeBases
@@ -376,27 +378,21 @@ do
           return
         end
 
-        for _, v in pairs(baseInfo.leftIcons) do
-          if v.iconState == 1 then
-            local str = v.state1Tooltip
-
+        for _, v in ipairs(baseInfo.leftIcons) do
+          if v.iconState == Enum.IconState.ShowState1 then
             allyIncBases = allyIncBases + 1
-
-            local base = smatch(str, "(.-) %-%s")
+            local base = smatch(v.state1Tooltip, "(.-) %-%s")
             -- if horde had the base, now they dont
             if hordeTimers[base] then
               hordeTimers[base] = nil
             end
             -- if fresh capture for alliance, or they once had it lose it fully then got it again
-            if allyTimers[base] == nil or (allyTimers[base] and allyTimers[base] - GetTime() <= 0) then
+            if allyTimers[base] == nil or allyTimers[base] - GetTime() <= 0 then
               allyTimers[base] = curMap.contestedTime + GetTime()
             end
-          elseif v.iconState == 2 then
-            local str = v.state2Tooltip
-
+          elseif v.iconState == Enum.IconState.ShowState2 then
             allyBases = allyBases + 1
-
-            local base = smatch(str, "(.-) %-%s")
+            local base = smatch(v.state2Tooltip, "(.-) %-%s")
             -- if taking a base from horde mid-cap
             if hordeTimers[base] then
               hordeTimers[base] = nil
@@ -408,27 +404,21 @@ do
           end
         end
 
-        for _, v in pairs(baseInfo.rightIcons) do
-          if v.iconState == 1 then
-            local str = v.state1Tooltip
-
+        for _, v in ipairs(baseInfo.rightIcons) do
+          if v.iconState == Enum.IconState.ShowState1 then
             hordeIncBases = hordeIncBases + 1
-
-            local base = smatch(str, "(.-) %-%s")
+            local base = smatch(v.state1Tooltip, "(.-) %-%s")
             -- if alliance had the base, now they dont
             if allyTimers[base] then
               allyTimers[base] = nil
             end
             -- if fresh capture for horde, or they once had it lose it fully then got it again
-            if hordeTimers[base] == nil or (hordeTimers[base] and hordeTimers[base] - GetTime() <= 0) then
+            if hordeTimers[base] == nil or hordeTimers[base] - GetTime() <= 0 then
               hordeTimers[base] = curMap.contestedTime + GetTime()
             end
-          elseif v.iconState == 2 then
-            local str = v.state2Tooltip
-
+          elseif v.iconState == Enum.IconState.ShowState2 then
             hordeBases = hordeBases + 1
-
-            local base = smatch(str, "(.-) %-%s")
+            local base = smatch(v.state2Tooltip, "(.-) %-%s")
             -- if taking a base from alliance mid-cap
             if allyTimers[base] then
               allyTimers[base] = nil
@@ -455,27 +445,21 @@ do
           return
         end
 
-        for _, v in pairs(baseInfo.leftIcons) do
-          if v.iconState == 1 then
-            local str = v.state1Tooltip
-
+        for _, v in ipairs(baseInfo.leftIcons) do
+          if v.iconState == Enum.IconState.ShowState1 then
             allyIncBases = allyIncBases + 1
-
-            local base = smatch(str, "(.-) %-%s")
+            local base = smatch(v.state1Tooltip, "(.-) %-%s")
             -- if horde had the base, now they dont
             if hordeTimers[base] then
               hordeTimers[base] = nil
             end
             -- if fresh capture for alliance
-            if allyTimers[base] == nil or (allyTimers[base] and allyTimers[base] - GetTime() <= 0) then
+            if allyTimers[base] == nil or allyTimers[base] - GetTime() <= 0 then
               allyTimers[base] = curMap.contestedTime + GetTime()
             end
-          elseif v.iconState == 2 then
-            local str = v.state2Tooltip
-
+          elseif v.iconState == Enum.IconState.ShowState2 then
             allyBases = allyBases + 1
-
-            local base = smatch(str, "(.-) %-%s")
+            local base = smatch(v.state2Tooltip, "(.-) %-%s")
             -- if taking a base from horde mid-cap
             if hordeTimers[base] then
               hordeTimers[base] = nil
@@ -487,27 +471,21 @@ do
           end
         end
 
-        for _, v in pairs(baseInfo.rightIcons) do
-          if v.iconState == 1 then
-            local str = v.state1Tooltip
-
+        for _, v in ipairs(baseInfo.rightIcons) do
+          if v.iconState == Enum.IconState.ShowState1 then
             hordeIncBases = hordeIncBases + 1
-
-            local base = smatch(str, "(.-) %-%s")
+            local base = smatch(v.state1Tooltip, "(.-) %-%s")
             -- if alliance had the base, now they dont
             if allyTimers[base] then
               allyTimers[base] = nil
             end
             -- if fresh capture for horde
-            if hordeTimers[base] == nil or (hordeTimers[base] and hordeTimers[base] - GetTime() <= 0) then
+            if hordeTimers[base] == nil or hordeTimers[base] - GetTime() <= 0 then
               hordeTimers[base] = curMap.contestedTime + GetTime()
             end
-          elseif v.iconState == 2 then
-            local str = v.state2Tooltip
-
+          elseif v.iconState == Enum.IconState.ShowState2 then
             hordeBases = hordeBases + 1
-
-            local base = smatch(str, "(.-) %-%s")
+            local base = smatch(v.state2Tooltip, "(.-) %-%s")
             -- if taking a base from alliance mid-cap
             if allyTimers[base] then
               allyTimers[base] = nil
@@ -534,27 +512,21 @@ do
           return
         end
 
-        for _, v in pairs(baseInfo.leftIcons) do
-          if v.iconState == 1 then
-            local str = v.state1Tooltip
-
+        for _, v in ipairs(baseInfo.leftIcons) do
+          if v.iconState == Enum.IconState.ShowState1 then
             allyIncBases = allyIncBases + 1
-
-            local base = smatch(str, "(.-) %-%s")
+            local base = smatch(v.state1Tooltip, "(.-) %-%s")
             -- if horde had the base, now they dont
             if hordeTimers[base] then
               hordeTimers[base] = nil
             end
             -- if fresh capture for alliance
-            if allyTimers[base] == nil or (allyTimers[base] and allyTimers[base] - GetTime() <= 0) then
+            if allyTimers[base] == nil or allyTimers[base] - GetTime() <= 0 then
               allyTimers[base] = curMap.contestedTime + GetTime()
             end
-          elseif v.iconState == 2 then
-            local str = v.state2Tooltip
-
+          elseif v.iconState == Enum.IconState.ShowState2 then
             allyBases = allyBases + 1
-
-            local base = smatch(str, "(.-) %-%s")
+            local base = smatch(v.state2Tooltip, "(.-) %-%s")
             -- if taking a base from horde mid-cap
             if hordeTimers[base] then
               hordeTimers[base] = nil
@@ -566,27 +538,21 @@ do
           end
         end
 
-        for _, v in pairs(baseInfo.rightIcons) do
-          if v.iconState == 1 then
-            local str = v.state1Tooltip
-
+        for _, v in ipairs(baseInfo.rightIcons) do
+          if v.iconState == Enum.IconState.ShowState1 then
             hordeIncBases = hordeIncBases + 1
-
-            local base = smatch(str, "(.-) %-%s")
+            local base = smatch(v.state1Tooltip, "(.-) %-%s")
             -- if alliance had the base, now they dont
             if allyTimers[base] then
               allyTimers[base] = nil
             end
             -- if fresh capture for horde
-            if hordeTimers[base] == nil or (hordeTimers[base] and hordeTimers[base] - GetTime() <= 0) then
+            if hordeTimers[base] == nil or hordeTimers[base] - GetTime() <= 0 then
               hordeTimers[base] = curMap.contestedTime + GetTime()
             end
-          elseif v.iconState == 2 then
-            local str = v.state2Tooltip
-
+          elseif v.iconState == Enum.IconState.ShowState2 then
             hordeBases = hordeBases + 1
-
-            local base = smatch(str, "(.-) %-%s")
+            local base = smatch(v.state2Tooltip, "(.-) %-%s")
             -- if taking a base from alliance mid-cap
             if allyTimers[base] then
               allyTimers[base] = nil
@@ -615,31 +581,29 @@ do
           return
         end
 
-        for _, v in pairs(baseInfo.leftIcons) do
-          if v.iconState == 1 then
+        for _, v in ipairs(baseInfo.leftIcons) do
+          local iconState = v.iconState
+          if iconState == Enum.IconState.ShowState1 then
             local str = v.state1Tooltip -- Alliance has assaulted the Mage Tower
 
             if sfind(str, "flag") == nil then
               allyIncBases = allyIncBases + 1
-
               local base = smatch(str, "assaulted the (.+)")
               -- if horde had the base, now they dont
               if hordeTimers[base] then
                 hordeTimers[base] = nil
               end
               -- if fresh capture for alliance
-              if allyTimers[base] == nil or (allyTimers[base] and allyTimers[base] - GetTime() <= 0) then
+              if allyTimers[base] == nil or allyTimers[base] - GetTime() <= 0 then
                 allyTimers[base] = curMap.contestedTime + GetTime()
               end
             else
               allyFlags = allyFlags + 1
             end
-          elseif v.iconState == 2 then
-            local str = v.state2Tooltip -- Alliance has captured the Mage Tower
-
+          elseif iconState == Enum.IconState.ShowState2 then
+            -- Alliance has captured the Mage Tower
             allyBases = allyBases + 1
-
-            local base = smatch(str, "captured the (.+)")
+            local base = smatch(v.state2Tooltip, "captured the (.+)")
             -- if taking a base from horde mid-cap
             if hordeTimers[base] then
               hordeTimers[base] = nil
@@ -651,31 +615,29 @@ do
           end
         end
 
-        for _, v in pairs(baseInfo.rightIcons) do
-          if v.iconState == 1 then
+        for _, v in ipairs(baseInfo.rightIcons) do
+          local iconState = v.iconState
+          if iconState == Enum.IconState.ShowState1 then
             local str = v.state1Tooltip -- Horde has assaulted the Mage Tower
 
             if sfind(str, "flag") == nil then
               hordeIncBases = hordeIncBases + 1
-
               local base = smatch(str, "assaulted the (.+)")
               -- if alliance had the base, now they dont
               if allyTimers[base] then
                 allyTimers[base] = nil
               end
               -- if fresh capture for horde
-              if hordeTimers[base] == nil or (hordeTimers[base] and hordeTimers[base] - GetTime() <= 0) then
+              if hordeTimers[base] == nil or hordeTimers[base] - GetTime() <= 0 then
                 hordeTimers[base] = curMap.contestedTime + GetTime()
               end
             else
               hordeFlags = hordeFlags + 1
             end
-          elseif v.iconState == 2 then
-            local str = v.state2Tooltip -- Horde has captured the Mage Tower
-
+          elseif iconState == Enum.IconState.ShowState2 then
+            -- Horde has captured the Mage Tower
             hordeBases = hordeBases + 1
-
-            local base = smatch(str, "captured the (.+)")
+            local base = smatch(v.state2Tooltip, "captured the (.+)")
             -- if taking a base from alliance mid-cap
             if allyTimers[base] then
               allyTimers[base] = nil
@@ -745,8 +707,8 @@ do
           return
         end
 
-        for _, v in pairs(baseInfo.leftIcons) do
-          if v.iconState == 1 then
+        for _, v in ipairs(baseInfo.leftIcons) do
+          if v.iconState == Enum.IconState.ShowState1 then
             local str = v.state1Tooltip
 
             allyIncBases = allyIncBases + 1
@@ -760,7 +722,7 @@ do
             if allyTimers[base] == nil or (allyTimers[base] and allyTimers[base] - GetTime() <= 0) then
               allyTimers[base] = curMap.contestedTime + GetTime()
             end
-          elseif v.iconState == 2 then
+          elseif v.iconState == Enum.IconState.ShowState2 then
             local str = v.state2Tooltip
 
             allyBases = allyBases + 1
@@ -777,8 +739,8 @@ do
           end
         end
 
-        for _, v in pairs(baseInfo.rightIcons) do
-          if v.iconState == 1 then
+        for _, v in ipairs(baseInfo.rightIcons) do
+          if v.iconState == Enum.IconState.ShowState1 then
             local str = v.state1Tooltip
 
             hordeIncBases = hordeIncBases + 1
@@ -792,7 +754,7 @@ do
             if hordeTimers[base] == nil or (hordeTimers[base] and hordeTimers[base] - GetTime() <= 0) then
               hordeTimers[base] = curMap.contestedTime + GetTime()
             end
-          elseif v.iconState == 2 then
+          elseif v.iconState == Enum.IconState.ShowState2 then
             local str = v.state2Tooltip
 
             hordeBases = hordeBases + 1
@@ -824,8 +786,8 @@ do
           return
         end
 
-        for _, v in pairs(baseInfo.leftIcons) do
-          if v.iconState == 1 then
+        for _, v in ipairs(baseInfo.leftIcons) do
+          if v.iconState == Enum.IconState.ShowState1 then
             local str = v.state1Tooltip -- Alliance has assaulted the Mage Tower
 
             if sfind(str, "flag") == nil then
@@ -841,7 +803,7 @@ do
                 allyTimers[base] = curMap.contestedTime + GetTime()
               end
             end
-          elseif v.iconState == 2 then
+          elseif v.iconState == Enum.IconState.ShowState2 then
             local str = v.state2Tooltip -- Alliance has captured the Mage Tower
 
             allyBases = allyBases + 1
@@ -858,8 +820,8 @@ do
           end
         end
 
-        for _, v in pairs(baseInfo.rightIcons) do
-          if v.iconState == 1 then
+        for _, v in ipairs(baseInfo.rightIcons) do
+          if v.iconState == Enum.IconState.ShowState1 then
             local str = v.state1Tooltip -- Horde has assaulted the Mage Tower
 
             if sfind(str, "flag") == nil then
@@ -875,7 +837,7 @@ do
                 hordeTimers[base] = curMap.contestedTime + GetTime()
               end
             end
-          elseif v.iconState == 2 then
+          elseif v.iconState == Enum.IconState.ShowState2 then
             local str = v.state2Tooltip -- Horde has captured the Mage Tower
 
             hordeBases = hordeBases + 1
@@ -954,29 +916,50 @@ do
           timeBetweenEachTick = elapsed % 1 >= 0.5 and mceil(elapsed) or mfloor(elapsed)
 
           After(0.5, function()
-            if NS.DEBUG then
-              print("aIncrease", aIncrease, prevAIncrease)
-              print("hIncrease", hIncrease, prevHIncrease)
-            end
-            if aIncrease ~= prevAIncrease or hIncrease ~= prevHIncrease or timeBetweenEachTick ~= prevTick then
-              -- > 60 increase means captured a flag in EOTS
-              if aIncrease > 60 or hIncrease > 60 then
+            if
+              aIncrease ~= prevAIncrease
+              or hIncrease ~= prevHIncrease
+              or timeBetweenEachTick ~= prevTick
+              or allyBases ~= prevABases
+              or hordeBases ~= prevHBases
+              or allyIncBases ~= prevAIncBases
+              or hordeIncBases ~= prevHIncBases
+            then
+              -- NS.Debug("START", aIncrease, hIncrease, "-----", aIncrease > 65, hIncrease > 65, "END")
+
+              -- > 65 increase means captured a flag in EOTS
+              -- 5 bases in AB/DWG blitz = 65 per tick
+              if aIncrease > 65 or hIncrease > 65 then
                 Interface:Clear()
 
-                if NS.DEBUG then
-                  print(
-                    "HERHERHERHERHER",
-                    NS.isEOTS(curMap.id),
-                    NS.isBlitz(),
-                    aScore ~= maxScore,
-                    hScore ~= maxScore,
-                    "HERHERHERHERHER"
-                  )
-                end
+                NS.Debug("TEST 1 TEST 1 TEST")
 
                 if NS.isEOTS(curMap.id) and NS.isBlitz() and aScore ~= maxScore and hScore ~= maxScore then
+                  NS.Debug("TEST 2 TEST 2 TEST")
+
                   Banner:Start(curMap.resetTime, "RESET")
+                else
+                  NS.Debug("OUT OUT OUT OUT OUT")
+
+                  prevAIncrease = -1
+                  prevHIncrease = -1
                 end
+
+                return
+              end
+
+              if
+                NS.isBlitz()
+                and (NS.isArathi(curMap.id) or NS.isDeepwind(curMap.id))
+                and aIncrease == 0
+                and hIncrease == 0
+                and aScore ~= maxScore
+                and hScore ~= maxScore
+                and (aScore > 0 or hScore > 0)
+              then
+                Interface:Clear()
+
+                NS.Debug("TEST 4 TEST 4 TEST")
 
                 prevAIncrease = -1
                 prevHIncrease = -1
@@ -1023,14 +1006,17 @@ do
       -- local
       prevTime, prevAScore, prevHScore, prevAIncrease, prevHIncrease = 0, 0, 0, 0, 0
       timeBetweenEachTick, prevTick, winTime = 0, 0, 0
-      minScore, maxScore, aScore, hScore, aIncrease, hIncrease = 0, 0, 0, 0, 0, 0
+      minScore, maxScore, aScore, hScore, aIncrease, hIncrease = 0, 1500, 0, 0, 0, 0
       prevABases, prevHBases, prevAIncBases, prevHIncBases = 0, 0, 0, 0
       -- global
       curMap = mapInfo
       allyBases, allyIncBases = 0, 0
       hordeBases, hordeIncBases = 0, 0
       allyFlags, hordeFlags = 0, 0
-      allyTimers, hordeTimers, winTable = {}, {}, {}
+
+      twipe(allyTimers)
+      twipe(hordeTimers)
+      twipe(winTable)
 
       NS.ACTIVE_BASE_COUNT = 0
       NS.INCOMING_BASE_COUNT = 0

--- a/predictions/carts.lua
+++ b/predictions/carts.lua
@@ -39,17 +39,17 @@ do
         return
       end
 
-      -- local barMinValue = captureInfo.barMinValue -- 100 (friendly)
-      -- local barMaxValue = captureInfo.barMaxValue -- 0 (enemy)
-      -- local barValue = captureInfo.barValue -- (starts at 50)
-      -- local isVisible = captureInfo.shownState -- 1 (shown) or 0 (not)
-      -- local neutralZoneCenter = captureInfo.neutralZoneCenter -- 50
-      -- local neutralZoneSize = captureInfo.neutralZoneSize -- 40/4 (40 on random eots/4 on carts)
+      local barMinValue = captureInfo.barMinValue -- 100 (friendly)
+      local barMaxValue = captureInfo.barMaxValue -- 0 (enemy)
+      local barValue = captureInfo.barValue -- (starts at 50)
+      local isVisible = captureInfo.shownState -- 1 (shown) or 0 (not)
+      local neutralZoneCenter = captureInfo.neutralZoneCenter -- 50
+      local neutralZoneSize = captureInfo.neutralZoneSize -- 40/4 (40 on random eots/4 on carts)
       -- so that means your team wins with 71+ (50+(40/2))=70
       -- 50 being middle and 40 point buffer (20 each side)
       -- 100 being fully controlled, 0 being enemy controlled
       -- so positive progression = taking it, negative = losing it
-      -- print("barValue", widgetID, barValue, isVisible == 1, neutralZoneCenter, neutralZoneSize)
+      NS.Debug("barValue", widgetID, barValue, isVisible == 1, neutralZoneCenter, neutralZoneSize)
     end
   end
 
@@ -68,12 +68,12 @@ do
         end
 
         for _, v in pairs(baseInfo.leftIcons) do
-          if v.iconState == 1 then
+          if v.iconState == Enum.IconState.ShowState1 then
             allyCarts = allyCarts + 1
           end
         end
         for _, v in pairs(baseInfo.rightIcons) do
-          if v.iconState == 1 then
+          if v.iconState == Enum.IconState.ShowState1 then
             hordeCarts = hordeCarts + 1
           end
         end
@@ -94,12 +94,12 @@ do
         end
 
         for _, v in pairs(baseInfo.leftIcons) do
-          if v.iconState == 1 then
+          if v.iconState == Enum.IconState.ShowState1 then
             allyCarts = allyCarts + 1
           end
         end
         for _, v in pairs(baseInfo.rightIcons) do
-          if v.iconState == 1 then
+          if v.iconState == Enum.IconState.ShowState1 then
             hordeCarts = hordeCarts + 1
           end
         end

--- a/predictions/orbs.lua
+++ b/predictions/orbs.lua
@@ -74,26 +74,27 @@ do
     -- aura.points[2] = Damage taken increase, ex: 60
     -- aura.points[3] = Damage done increase, ex: 20
     local function updateOrbStacks(unitTarget, orbKey, spellId, changeType, updateInfo, isRemoved)
-      local name, realm = UnitName(unitTarget)
-      local nameAndRealm = realm and (name .. "-" .. realm) or (name .. "-" .. GetRealmName())
+      local nameAndRealm = NS.GetUnitNameAndRealm(unitTarget)
 
-      if orbCarriers[orbKey] == nameAndRealm then
-        if changeType == "update" or changeType == "remove" then
-          for _, auraInstanceID in ipairs(updateInfo) do
-            local aura = GetAuraDataByAuraInstanceID(unitTarget, auraInstanceID)
-            if aura and aura.spellId == spellId then
-              orbStacks[orbKey] = isRemoved and 0 or aura.points[2]
-              Orbs:StartOrbList(orbStacks)
-              break
-            end
+      if orbCarriers[orbKey] ~= nameAndRealm then
+        return
+      end
+
+      if changeType == "update" or changeType == "remove" then
+        for _, auraInstanceID in ipairs(updateInfo) do
+          local aura = GetAuraDataByAuraInstanceID(unitTarget, auraInstanceID)
+          if aura and aura.spellId == spellId then
+            orbStacks[orbKey] = isRemoved and 0 or aura.points[2]
+            Orbs:StartOrbList(orbStacks)
+            break
           end
-        elseif changeType == "add" then
-          for _, aura in ipairs(updateInfo) do
-            if aura and aura.spellId == spellId then
-              orbStacks[orbKey] = aura.points[2]
-              Orbs:StartOrbList(orbStacks)
-              break
-            end
+        end
+      elseif changeType == "add" then
+        for _, aura in ipairs(updateInfo) do
+          if aura and aura.spellId == spellId then
+            orbStacks[orbKey] = aura.points[2]
+            Orbs:StartOrbList(orbStacks)
+            break
           end
         end
       end
@@ -163,7 +164,7 @@ do
 
         -- temple base states are always state 1 which is technically contested in all other maps
         for _, v in pairs(baseInfo.leftIcons) do
-          if v.iconState == 1 then
+          if v.iconState == Enum.IconState.ShowState1 then
             local str = v.state1Tooltip
 
             allyOrbs = allyOrbs + 1
@@ -174,7 +175,7 @@ do
         end
 
         for _, v in pairs(baseInfo.rightIcons) do
-          if v.iconState == 1 then
+          if v.iconState == Enum.IconState.ShowState1 then
             local str = v.state1Tooltip
 
             hordeOrbs = hordeOrbs + 1
@@ -201,7 +202,7 @@ do
 
         -- temple base states are always state 1 which is technically contested in all other maps
         for _, v in pairs(baseInfo.leftIcons) do
-          if v.iconState == 1 then
+          if v.iconState == Enum.IconState.ShowState1 then
             local str = v.state1Tooltip
 
             allyOrbs = allyOrbs + 1
@@ -212,7 +213,7 @@ do
         end
 
         for _, v in pairs(baseInfo.rightIcons) do
-          if v.iconState == 1 then
+          if v.iconState == Enum.IconState.ShowState1 then
             local str = v.state1Tooltip
 
             hordeOrbs = hordeOrbs + 1
@@ -235,8 +236,7 @@ do
           or spellId == orbTypes["Orange"]
           or spellId == orbTypes["Purple"]
         then
-          local name, realm = UnitName(unitID)
-          local nameAndRealm = realm and (name .. "-" .. realm) or (name .. "-" .. GetRealmName())
+          local nameAndRealm = NS.GetUnitNameAndRealm(unitID)
           if spellId == orbTypes["Blue"] then
             local debuffPercentage = select(17, ...)
             orbCarriers["Blue"] = nameAndRealm


### PR DESCRIPTION
- Complete overhaul of map controller managing entering/exiting bgs and their state
- Adding Deephaul Ravine to the list of maps, but not yet completed
- New supporting helpers from event and state refactoring
- Adding some additional conditional checks from recent testing and bugs
- Map settings overhaul for all maps to create common configs for easy switching between blitz and regular bgs
- Leveraging blizzard api enums over hard coded values in conditionals
- Using variables for max scores instead of hard coded values
- Changing checks in base caps to proper conditional lua statements
- Adding additional checks for win con triggers to include inc base changes not just point changes
- Fixing base reset on blitz eots to always show correctly
- Adding an additional check for flag caps to reset stacks
- Reverting flag cap functions back to inline handling logic per battleground message
- Adding early out on orbs if unit isn't a carrier
- Updating db cleanup function to ignore lastReadVersion and lastFlagCapBy as those are set dynamically
- New simplified interface start function
- New changelog manager and dialog lib
- Adding version check code
- Drag and Click control updates to ensure click through when hidden or locked
- Fixing font dropdown list
- Updating font size range
- Minor Cleanup
- Update toc